### PR TITLE
Updates to Collection and TokenMetadata: Derive attributes

### DIFF
--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -285,11 +285,10 @@ class Collection:
                 str_attr,
             ) in token.metadata.string_attributes.items():
                 normalized_name = normalize_attribute_string(attr_name)
-                normalized_value = normalize_attribute_string(str_attr.value)
-                if normalized_value not in attrs_freq_counts[attr_name]:
-                    attrs_freq_counts[normalized_name][normalized_value] = 1
+                if str_attr.value not in attrs_freq_counts[attr_name]:
+                    attrs_freq_counts[normalized_name][str_attr.value] = 1
                 else:
-                    attrs_freq_counts[normalized_name][normalized_value] += 1
+                    attrs_freq_counts[normalized_name][str_attr.value] += 1
 
         return dict(attrs_freq_counts)
 

--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -142,41 +142,6 @@ class Collection:
             token_standards.add(token.token_standard)
         return list(token_standards)
 
-    def _normalize_attributes_frequency_counts(
-        self,
-        attributes_frequency_counts: dict[
-            AttributeName, dict[AttributeValue, int]
-        ],
-    ) -> dict[AttributeName, dict[AttributeValue, int]]:
-        """We normalize all collection attributes to ensure that neither casing nor
-        leading/trailing spaces produce different attributes:
-            (e.g. 'Hat' == 'hat' == 'hat ')
-        If a collection has the following in their attributes frequency counts:
-            ('Hat', 'beanie') 5 tokens and
-            ('hat', 'beanie') 10 tokens
-        this would produce: ('hat', 'beanie') 15 tokens
-        """
-        normalized: dict[AttributeName, dict[AttributeValue, int]] = {}
-        for (
-            attr_name,
-            attr_value_to_count,
-        ) in attributes_frequency_counts.items():
-            normalized_name = normalize_attribute_string(attr_name)
-            if normalized_name not in normalized:
-                normalized[normalized_name] = {}
-            for attr_value, attr_count in attr_value_to_count.items():
-                normalized_value = (
-                    normalize_attribute_string(attr_value)
-                    if isinstance(attr_value, str)
-                    else attr_value
-                )
-                if normalized_value not in normalized[normalized_name]:
-                    normalized[normalized_name][normalized_value] = attr_count
-                else:
-                    normalized[normalized_name][normalized_value] += attr_count
-
-        return normalized
-
     def total_tokens_with_attribute(self, attribute: StringAttribute) -> int:
         """Returns the numbers of tokens in this collection with the attribute
         based on the attributes frequency counts.
@@ -260,6 +225,41 @@ class Collection:
                 )
 
         return collection_traits
+
+    def _normalize_attributes_frequency_counts(
+        self,
+        attributes_frequency_counts: dict[
+            AttributeName, dict[AttributeValue, int]
+        ],
+    ) -> dict[AttributeName, dict[AttributeValue, int]]:
+        """We normalize all collection attributes to ensure that neither casing nor
+        leading/trailing spaces produce different attributes:
+            (e.g. 'Hat' == 'hat' == 'hat ')
+        If a collection has the following in their attributes frequency counts:
+            ('Hat', 'beanie') 5 tokens and
+            ('hat', 'beanie') 10 tokens
+        this would produce: ('hat', 'beanie') 15 tokens
+        """
+        normalized: dict[AttributeName, dict[AttributeValue, int]] = {}
+        for (
+            attr_name,
+            attr_value_to_count,
+        ) in attributes_frequency_counts.items():
+            normalized_name = normalize_attribute_string(attr_name)
+            if normalized_name not in normalized:
+                normalized[normalized_name] = {}
+            for attr_value, attr_count in attr_value_to_count.items():
+                normalized_value = (
+                    normalize_attribute_string(attr_value)
+                    if isinstance(attr_value, str)
+                    else attr_value
+                )
+                if normalized_value not in normalized[normalized_name]:
+                    normalized[normalized_name][normalized_value] = attr_count
+                else:
+                    normalized[normalized_name][normalized_value] += attr_count
+
+        return normalized
 
     def _derive_normalized_attributes_frequency_counts(
         self,

--- a/open_rarity/models/token.py
+++ b/open_rarity/models/token.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
+from typing import Any
 
-from open_rarity.models.token_identifier import TokenIdentifier
-from open_rarity.models.token_metadata import TokenMetadata
+from open_rarity.models.token_identifier import (
+    EVMContractTokenIdentifier,
+    TokenIdentifier,
+)
+from open_rarity.models.token_metadata import AttributeName, TokenMetadata
 from open_rarity.models.token_standard import TokenStandard
 
 
@@ -24,6 +28,46 @@ class Token:
     token_identifier: TokenIdentifier
     token_standard: TokenStandard
     metadata: TokenMetadata
+
+    @classmethod
+    def from_erc721(
+        cls,
+        contract_address: str,
+        token_id: int,
+        metadata_dict: dict[AttributeName, Any],
+    ):
+        """Creates a Token class representing an ERC721 evm token given the following
+        parameters.
+
+        Parameters
+        ----------
+        contract_address : str
+            Contract address of the token
+        token_id : int
+            Token ID number of the token
+        metadata_dict : dict
+            Dictionary of attribute name to attribute value for the given token.
+            The type of the value determines whether the attribute is a string,
+            numeric or date attribute.
+
+            class           attribute type
+            ------------    -------------
+            string          string attribute
+            int | float     numeric_attribute
+            datetime        date_attribute (stored as timestamp, seconds from epoch)
+
+        Returns
+        -------
+        Token
+            A Token instance with EVMContractTokenIdentifier and ERC721 standard set.
+        """
+        return cls(
+            token_identifier=EVMContractTokenIdentifier(
+                contract_address=contract_address, token_id=token_id
+            ),
+            token_standard=TokenStandard.ERC721,
+            metadata=TokenMetadata.from_attributes(metadata_dict),
+        )
 
     def __str__(self):
         return f"Token[{self.token_identifier}]"

--- a/open_rarity/models/token.py
+++ b/open_rarity/models/token.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from open_rarity.models.token_identifier import TokenIdentifier
 from open_rarity.models.token_metadata import TokenMetadata
 from open_rarity.models.token_standard import TokenStandard
-from open_rarity.models.utils.attribute_utils import normalize_attribute_string
 
 
 @dataclass
@@ -25,48 +24,6 @@ class Token:
     token_identifier: TokenIdentifier
     token_standard: TokenStandard
     metadata: TokenMetadata
-
-    def __post_init__(self):
-        self.metadata = self._normalize_metadata(self.metadata)
-
-    def _normalize_metadata(self, metadata: TokenMetadata) -> TokenMetadata:
-        """Normalizes token metadata to ensure the attribute names are lower cased
-        and whitespace stripped to ensure equality consistency.
-
-        Parameters
-        ----------
-        metadata : TokenMetadata
-            The original token metadata
-
-        Returns
-        -------
-        TokenMetadata
-            A new normalized token metadata
-        """
-
-        def normalize_and_reset(attributes_dict: dict):
-            """Helper function that takes in an attributes dictionary
-            and normalizes both attribute name in the dictionary as the key
-            and the repeated field inside the <Type>Attribute class
-            """
-            normalized_attributes_dict = {}
-
-            for attribute_name, attr in attributes_dict.items():
-                normalized_attr_name = normalize_attribute_string(
-                    attribute_name
-                )
-                normalized_attributes_dict[normalized_attr_name] = attr
-                if attr.name != normalized_attr_name:
-                    attr.name = normalized_attr_name
-            return normalized_attributes_dict
-
-        return TokenMetadata(
-            string_attributes=normalize_and_reset(metadata.string_attributes),
-            numeric_attributes=normalize_and_reset(
-                metadata.numeric_attributes
-            ),
-            date_attributes=normalize_and_reset(metadata.date_attributes),
-        )
 
     def __str__(self):
         return f"Token[{self.token_identifier}]"

--- a/open_rarity/models/token_metadata.py
+++ b/open_rarity/models/token_metadata.py
@@ -122,6 +122,8 @@ class TokenMetadata:
         for attribute_name, attr in attributes_dict.items():
             normalized_attr_name = normalize_attribute_string(attribute_name)
             normalized_attributes_dict[normalized_attr_name] = attr
+            if normalized_attr_name != attr.name:
+                attr.name = normalized_attr_name
         return normalized_attributes_dict
 
     @classmethod

--- a/scripts/score_generated_collection.py
+++ b/scripts/score_generated_collection.py
@@ -1,58 +1,29 @@
 from open_rarity import (
     Collection,
-    EVMContractTokenIdentifier,
     OpenRarityScorer,
-    StringAttribute,
     Token,
-    TokenMetadata,
-    TokenStandard,
 )
 
 if __name__ == "__main__":
     scorer = OpenRarityScorer()
-    # A collection of 2 tokens
+
     collection = Collection(
         name="My Collection Name",
-        attributes_frequency_counts={
-            "hat": {"cap": 1, "visor": 2},
-            "shirt": {"blue": 2, "green": 1},
-        },
         tokens=[
-            Token(
-                token_identifier=EVMContractTokenIdentifier(
-                    contract_address="0xa3049...", token_id=1
-                ),
-                token_standard=TokenStandard.ERC721,
-                metadata=TokenMetadata(
-                    string_attributes={
-                        "hat": StringAttribute(name="hat", value="cap"),
-                        "shirt": StringAttribute(name="shirt", value="blue"),
-                    }
-                ),
+            Token.from_erc721(
+                contract_address="0xa3049...",
+                token_id=1,
+                metadata_dict={"hat": "cap", "shirt": "blue"},
             ),
-            Token(
-                token_identifier=EVMContractTokenIdentifier(
-                    contract_address="0xa3049...", token_id=2
-                ),
-                token_standard=TokenStandard.ERC721,
-                metadata=TokenMetadata(
-                    string_attributes={
-                        "hat": StringAttribute(name="hat", value="visor"),
-                        "shirt": StringAttribute(name="shirt", value="green"),
-                    }
-                ),
+            Token.from_erc721(
+                contract_address="0xa3049...",
+                token_id=2,
+                metadata_dict={"hat": "visor", "shirt": "green"},
             ),
-            Token(
-                token_identifier=EVMContractTokenIdentifier(
-                    contract_address="0xa3049...", token_id=3
-                ),
-                token_standard=TokenStandard.ERC721,
-                metadata=TokenMetadata(
-                    string_attributes={
-                        "hat": StringAttribute(name="hat", value="visor"),
-                        "shirt": StringAttribute(name="shirt", value="blue"),
-                    }
-                ),
+            Token.from_erc721(
+                contract_address="0xa3049...",
+                token_id=3,
+                metadata_dict={"hat": "visor", "shirt": "blue"},
             ),
         ],
     )  # Replace inputs with your collection-specific details here

--- a/scripts/score_generated_collection.py
+++ b/scripts/score_generated_collection.py
@@ -3,6 +3,7 @@ from open_rarity import (
     OpenRarityScorer,
     Token,
 )
+from open_rarity.rarity_ranker import RarityRanker
 
 if __name__ == "__main__":
     scorer = OpenRarityScorer()
@@ -37,4 +38,10 @@ if __name__ == "__main__":
     token = collection.tokens[0]  # Your token details filled in
     token_score = scorer.score_token(collection=collection, token=token)
 
-    print(f"Token score: {token_score}")
+    # Better yet.. just use ranker directly!
+    ranked_tokens = RarityRanker.rank_collection(collection=collection)
+    for ranked_token in ranked_tokens:
+        print(
+            f"Token {ranked_token.token} has rank {ranked_token.rank} "
+            "and score {ranked_token.score}"
+        )

--- a/tests/models/test_token.py
+++ b/tests/models/test_token.py
@@ -1,13 +1,42 @@
+from open_rarity.models.token import Token
+from open_rarity.models.token_identifier import EVMContractTokenIdentifier
 from open_rarity.models.token_metadata import (
     NumericAttribute,
     StringAttribute,
     TokenMetadata,
 )
+from open_rarity.models.token_standard import TokenStandard
 
 from tests.helpers import create_evm_token
 
 
 class TestToken:
+    def test_create_erc721(self):
+        token = Token(
+            token_identifier=EVMContractTokenIdentifier(
+                contract_address="0xa3049...", token_id=1
+            ),
+            token_standard=TokenStandard.ERC721,
+            metadata=TokenMetadata.from_attributes(
+                {"hat": "cap", "shirt": "blue"}
+            ),
+        )
+        token_equal = Token.from_erc721(
+            contract_address="0xa3049...",
+            token_id=1,
+            metadata_dict={"hat": "cap", "shirt": "blue"},
+        )
+
+        assert token == token_equal
+
+        token_not_equal = Token.from_erc721(
+            contract_address="0xmew...",
+            token_id=1,
+            metadata_dict={"hat": "cap", "shirt": "blue"},
+        )
+
+        assert token != token_not_equal
+
     def test_token_init_metadata_non_matching_attribute_names(self):
         token = create_evm_token(
             token_id=1,

--- a/tests/models/test_token_metadata.py
+++ b/tests/models/test_token_metadata.py
@@ -1,0 +1,51 @@
+import pytest
+from open_rarity.models.token_metadata import (
+    DateAttribute,
+    NumericAttribute,
+    StringAttribute,
+    TokenMetadata,
+)
+from datetime import datetime
+
+
+class TestTokenMetadata:
+    def test_from_attributes_valid_types(self):
+        created = datetime.now()
+        token_metadata = TokenMetadata.from_attributes(
+            {
+                "hat": "blue cap",
+                "created": created,
+                "integer trait": 1,
+                "float trait": 203.5,
+                "PANTS ": "jeans",
+            }
+        )
+
+        assert token_metadata.string_attributes == {
+            "hat": StringAttribute(name="hat", value="blue cap"),
+            "pants": StringAttribute(name="pants", value="jeans"),
+        }
+        assert token_metadata.numeric_attributes == {
+            "integer trait": NumericAttribute(name="integer trait", value=1),
+            "float trait": NumericAttribute(name="float trait", value=203.5),
+        }
+        assert token_metadata.date_attributes == {
+            "created": DateAttribute(
+                name="created", value=int(created.timestamp())
+            ),
+        }
+
+    def test_from_attributes_invalid_type(self):
+        with pytest.raises(TypeError) as excinfo:
+            TokenMetadata.from_attributes(
+                {
+                    "hat": "blue cap",
+                    "created": {"bad input": "true"},
+                    "integer trait": 1,
+                    "float trait": 203.5,
+                }
+            )
+
+        assert "Provided attribute value has invalid type" in str(
+            excinfo.value
+        )


### PR DESCRIPTION
- In `Collection`, make init field `attributes_frequency_counts` optional and if not provided, we fill derive frequency from the collection's tokens' metadata.
- Added a helper method to `TokenMetadata` to more easily construct metadata, e.g. instead of having to:
```
# Original way:
TokenMetadata(
      string_attributes={
          "hat": StringAttribute(name="hat", value="blue"),
          "shirt": StringAttribute(name="shirt", value="red"),
      },
      numeric_attributes={
          "level": NumericAttribute(name="level", value=1),
      },
  ),
```
New optional way:
```
TokenMetadata.from_attributes(
      {
          "hat": "blue",
          "shirt": "red",
          "level": 1,
      }
  )
```
- Additionally, added another factory method for `Token`:
Before:
```
Token(
    token_identifier=EVMContractTokenIdentifier(
        contract_address="0xa3049...", token_id=1
    ),
    token_standard=TokenStandard.ERC721,
    metadata=TokenMetadata(
        string_attributes={
            "hat": StringAttribute(name="hat", value="cap"),
            "shirt": StringAttribute(name="shirt", value="blue"),
        }
    )
```
Now you can do:
```
Token.from_erc721(
    contract_address="0xa3049...",
    token_id=1,
    metadata_dict={"hat": "cap", "shirt": "blue"},
)
```