### PR TITLE
Make token identifiers hashable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributions guide
+
+OpenRarity is a cross-company effort to improve rarity computation for NFTs (Non-Fungible Tokens). The core collaboration group consists of four primary contributors: Curio, icy.tools, OpenSea and Proof
+
+OpenRarity is an open-source project with Apache 2.0 license and all contributions are welcome. Consider following steps when you request/propose contribution:
+
+* Have a question? Submit it on OpenRarity GitHub discussions page
+* Create GitHub issue/bug with description of the problem link
+* Submit Pull Request with proposed changes
+* To merge the change in the main branch you required to get at least 2 approvals from the project maintainer list
+* Always add a unit test with your changes.
+
+
+# Code formatting
+We use git-precommit hooks in OpenRarity repo. Install it with the following command
+
+`poetry run pre-commit install`
+
+
+# IDE 
+We recommend to use VS Ccode with python support enabled.
+
+

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ python -m scripts.score_real_collections boredapeyachtclub proof-moonbirds
 You may use the rarity resolver tool to either view ranking scores across providers, or to debug any collections scoring. Follow these steps to score the collection with the tool (by calling OpenSea API):
 
 - Curate the <a href="https://github.com/ProjectOpenSea/open-rarity/blob/main/open_rarity/data/test_collections.json" title=“Collections>collections list </a> you want to score with OpenRarity
-- Provide your <a href="https://github.com/ProjectOpenSea/open-rarity/blob/main/open_rarity/resolver/opensea_api_helpers.py#L20"> OpenSea API Key </a>
 - Run scoring for these collections with the following command:
 
     ```python

--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -44,10 +44,17 @@ class Collection:
         dictionary of attributes to the number of tokens in this collection that has
         a specific value for every possible value for the given attribute.
 
+        If not provided, the attributes distribution will be derived from the
+        attributes on the tokens provided.
+
         Example:
             {"hair": {"brown": 500, "blonde": 100}
             which means 500 tokens has hair=brown, 100 token has hair=blonde
-        All trait names and values should be lowercased.
+
+        Note: All trait names and string values should be lowercased and stripped
+        of leading and trialing whitespace.
+        Note 2: We currently only support string attributes.
+
     name: A reference string only used for debugger log lines
 
     We do not recommend resetting @tokens attribute after Collection initialization
@@ -68,30 +75,6 @@ class Collection:
         | None = None,
         name: str | None = "",
     ):
-        """
-        Parameters
-        ----------
-        tokens : list[Token]
-            list of all tokens that belong to the collection. Must have meteadata
-            properly set if attributes_frequency_counts is not provided.
-        attributes_frequency_counts:
-            dict[AttributeName, dict[AttributeValue, int]] | None, optional
-            dictionary of attributes to the number of tokens in this collection
-            that has a specific value for every possible value for the given
-            attribute, by default None.
-            If not provided, the attributes distribution will be derived from the
-            attributes on the tokens provided.
-
-            Example:
-                {"hair": {"brown": 500, "blonde": 100}
-                which means 500 tokens has hair=brown, 100 token has hair=blonde
-            Note: All trait names and string values should be lowercased and stripped
-            of leading and trialing whitespace.
-            Note 2: We currently only support string attributes in
-                attributes_frequency_counts
-        name : str | None, optional
-            A reference string only used for debugging or identification, by default ""
-        """
         self._tokens = tokens
         self.name = name or ""
         if attributes_frequency_counts:

--- a/open_rarity/models/token_identifier.py
+++ b/open_rarity/models/token_identifier.py
@@ -20,7 +20,9 @@ class EVMContractTokenIdentifier:
         return f"Contract({self.contract_address}) #{self.token_id}"
 
     def __hash__(self):
-        return hash((self.contract_address, self.token_id, self.identifier_type))
+        return hash(
+            (self.contract_address, self.token_id, self.identifier_type)
+        )
 
 
 @dataclass

--- a/open_rarity/models/token_identifier.py
+++ b/open_rarity/models/token_identifier.py
@@ -19,6 +19,9 @@ class EVMContractTokenIdentifier:
     def __str__(self):
         return f"Contract({self.contract_address}) #{self.token_id}"
 
+    def __hash__(self):
+        return hash((self.contract_address, self.token_id, self.identifier_type))
+
 
 @dataclass
 class SolanaMintAddressTokenIdentifier:
@@ -33,6 +36,9 @@ class SolanaMintAddressTokenIdentifier:
 
     def __str__(self):
         return f"MintAddress({self.mint_address})"
+
+    def __hash__(self):
+        return hash((self.mint_address, self.identifier_type))
 
 
 # This is used to specifies how the collection is identified and the


### PR DESCRIPTION
This change makes the token identifiers `EVMContractTokenIdentifier` and `SolanaMintAddressTokenIdentifier` hashable. This will allows people to use `token.token_identifier` as a dictionary key if they want to transform data returned from the library.