### PR TITLE
Fix token id hash bug

### DIFF
--- a/open_rarity/models/token_identifier.py
+++ b/open_rarity/models/token_identifier.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 from pydantic import Field
 
 
-@dataclass
+@dataclass(frozen=True)
 class EVMContractTokenIdentifier:
     """This token is identified by the contract address and token ID number.
 
@@ -19,23 +19,8 @@ class EVMContractTokenIdentifier:
     def __str__(self):
         return f"Contract({self.contract_address}) #{self.token_id}"
 
-    def __eq__(self, other):
-        if not isinstance(other, EVMContractTokenIdentifier):
-            return False
 
-        return (
-            self.contract_address == other.contract_address
-            and self.token_id == other.token_id
-            and self.identifier_type == other.identifier_type
-        )
-
-    def __hash__(self):
-        return hash(
-            (self.contract_address, self.token_id, self.identifier_type)
-        )
-
-
-@dataclass
+@dataclass(frozen=True)
 class SolanaMintAddressTokenIdentifier:
     """This token is identified by their solana account address.
 
@@ -48,18 +33,6 @@ class SolanaMintAddressTokenIdentifier:
 
     def __str__(self):
         return f"MintAddress({self.mint_address})"
-
-    def __eq__(self, other):
-        if not isinstance(other, SolanaMintAddressTokenIdentifier):
-            return False
-
-        return (
-            self.mint_address == other.mint_address
-            and self.identifier_type == other.identifier_type
-        )
-
-    def __hash__(self):
-        return hash((self.mint_address, self.identifier_type))
 
 
 # This is used to specifies how the collection is identified and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-rarity"
-version = "0.4.2-beta"
+version = "0.4.3-beta"
 description = "Open-Rarity library is an open standard that provides an easy, explanable and reproducible computation for NFT rarity"
 authors = ["Dan Meshkov <daniil.meshkov@opensea.io>", "Vicky Gong <vicky.gong@opensea.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This change fixes an issue with the token identifier hash.

Unfortunately, we cannot override `__hash__` for dataclasses. The proper way to make dataclass hashable is to set `frozen=True` https://docs.python.org/3/library/dataclasses.html#module-contents.