### PR TITLE
#58: added batch_size parameter to the opensea_api_helpers.get_collection_from_opensea  function

### DIFF
--- a/open_rarity/resolver/opensea_api_helpers.py
+++ b/open_rarity/resolver/opensea_api_helpers.py
@@ -275,7 +275,7 @@ def get_collection_with_metadata_from_opensea(
 
 
 def get_collection_from_opensea(
-    opensea_collection_slug: str,
+    opensea_collection_slug: str, batch_size: int = 30
 ) -> Collection:
     """Fetches collection and token data with OpenSea endpoint and API key
     and stores it in the Collection object
@@ -284,6 +284,11 @@ def get_collection_from_opensea(
     ----------
     opensea_collection_slug : str
         collection slug on opensea's system
+
+    batch_size: int
+        controls batch size for the opensea API requests
+        maximum value is 30
+
 
     Returns
     -------
@@ -307,7 +312,6 @@ def get_collection_from_opensea(
 
     # Fetch token metadata
     tokens: list[Token] = []
-    batch_size = 30
     num_batches = math.ceil(total_supply / batch_size)
     initial_token_id = 0
 

--- a/open_rarity/resolver/opensea_api_helpers.py
+++ b/open_rarity/resolver/opensea_api_helpers.py
@@ -286,9 +286,8 @@ def get_collection_from_opensea(
         collection slug on opensea's system
 
     batch_size: int
-        controls batch size for the opensea API requests
+        batch size for the opensea API requests
         maximum value is 30
-
 
     Returns
     -------


### PR DESCRIPTION
# Summary
GH issue https://github.com/OpenRarity/open-rarity/issues/58. 
Added `batch_size` parameter to the top-level api of the `opensea_api_helpers.get_collection_from_opensea` function. The maximum batch_size is `30`.

# Tests
Pytest
`python -m scripts.score_real_collections proof-moonbirds`