### PR TITLE
External Resolvers - Small fixes, improvements and non-breaking refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ score_real_collections_results*.json
 
 # Local cache files
 cached_data/*.json
+cached_data/*/*.json

--- a/open_rarity/resolver/rarity_providers/external_rarity_provider.py
+++ b/open_rarity/resolver/rarity_providers/external_rarity_provider.py
@@ -166,6 +166,8 @@ class ExternalRarityProvider:
                 token_id = str(ts_rank_data["token_id"])
                 rank_cache[token_id] = int(ts_rank_data["rarity_rank"])
 
+            self.write_cache_to_file(slug, rank_provider)
+
         for token_with_rarity in tokens_with_rarity:
             token = token_with_rarity.token
             token_identifer = token.token_identifier
@@ -232,6 +234,7 @@ class ExternalRarityProvider:
                 logger.debug(
                     f"Fetched {num_tokens} token ranks from rarity sniffer API"
                 )
+                self.write_cache_to_file(slug, rank_provider)
             except Exception:
                 logger.exception("Failed to resolve token_ids Rarity Sniffer")
                 raise
@@ -336,6 +339,7 @@ class ExternalRarityProvider:
         for rank_provider in rank_providers:
             # Note: Not all providers have rankings for all collections,
             # so do a best effort.
+            print("\t\tProcessing provider: ", rank_provider)
             try:
                 if rank_provider == RankProvider.RARITY_SNIFFER:
                     self._add_rarity_sniffer_rarity_data(

--- a/open_rarity/resolver/rarity_providers/external_rarity_provider.py
+++ b/open_rarity/resolver/rarity_providers/external_rarity_provider.py
@@ -11,9 +11,9 @@ from open_rarity.resolver.models.token_with_rarity_data import (
     TokenWithRarityData,
 )
 
-from .rarity_sniffer import RaritySnifferProvider
-from .rarity_sniper import RaritySniperProvider
-from .trait_sniper import TraitSniperProvider
+from .rarity_sniffer import RaritySnifferResolver
+from .rarity_sniper import RaritySniperResolver
+from .trait_sniper import TraitSniperResolver
 
 logger = logging.getLogger("open_rarity_logger")
 
@@ -142,7 +142,7 @@ class ExternalRarityProvider:
             contract_addresses = collection_with_metadata.contract_addresses
             assert (len(contract_addresses)) == 1
             try:
-                trait_sniper_rank_data = TraitSniperProvider.get_all_ranks(
+                trait_sniper_rank_data = TraitSniperResolver.get_all_ranks(
                     contract_address=contract_addresses[0]
                 )
                 logger.debug(
@@ -225,7 +225,7 @@ class ExternalRarityProvider:
         # If there was no cache data available, make API request to fetch data
         if not self._is_cache_loaded(slug, rank_provider):
             try:
-                token_ids_to_ranks = RaritySnifferProvider.get_ranks(
+                token_ids_to_ranks = RaritySnifferResolver.get_ranks(
                     contract_address=contract_address
                 )
 
@@ -264,7 +264,7 @@ class ExternalRarityProvider:
     ) -> list[TokenWithRarityData]:
         # We're currently using opensea slug to calculate trait sniper slug
         opensea_slug = collection_with_metadata.opensea_slug
-        slug = RaritySniperProvider.get_slug(opensea_slug=opensea_slug)
+        slug = RaritySniperResolver.get_slug(opensea_slug=opensea_slug)
         rank_provider = RankProvider.RARITY_SNIPER
         if cache_external_ranks:
             self._load_cache_from_file(slug=opensea_slug, rank_provider=rank_provider)
@@ -283,7 +283,7 @@ class ExternalRarityProvider:
 
             if rank is None:
                 try:
-                    rank = RaritySniperProvider.get_rank(
+                    rank = RaritySniperResolver.get_rank(
                         collection_slug=slug, token_id=token_id
                     )
                     logger.debug(

--- a/open_rarity/resolver/rarity_providers/rank_resolver.py
+++ b/open_rarity/resolver/rarity_providers/rank_resolver.py
@@ -1,0 +1,9 @@
+from abc import abstractmethod
+from typing import Protocol
+
+
+class RankResolver(Protocol):
+    @staticmethod
+    @abstractmethod
+    def get_all_ranks(contract_address: str | None, slug: str | None) -> dict[str, int]:
+        raise NotImplementedError

--- a/open_rarity/resolver/rarity_providers/rank_resolver.py
+++ b/open_rarity/resolver/rarity_providers/rank_resolver.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
+@runtime_checkable
 class RankResolver(Protocol):
     @staticmethod
     @abstractmethod

--- a/open_rarity/resolver/rarity_providers/rarity_sniffer.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniffer.py
@@ -1,0 +1,84 @@
+import logging
+
+import requests
+
+logger = logging.getLogger("open_rarity_logger")
+RARITY_SNIFFER_API_URL = "https://raritysniffer.com/api/index.php"
+RARITY_SNIPER_API_URL = (
+    "https://api.raritysniper.com/public/collection/{slug}/id/{token_id}"
+)
+USER_AGENT = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"  # noqa: E501
+    )
+}
+
+
+class RaritySnifferProvider:
+    @staticmethod
+    def get_ranks(contract_address: str) -> dict[str, int]:
+        """Fetches all available tokens and ranks
+        for a given collection from rarity sniffer.
+        Only usable for EVM tokens and collections for a single
+        contract address.
+
+        Parameters
+        ----------
+        contract_address : The contract address of the collection
+
+        Returns
+        -------
+        dict[int, int]: Dictionary of token ID # to the rank. Empty if no data.
+
+        Raises
+        ------
+        Exception
+            If call to the rarity sniffer failed the method throws exception
+        """
+
+        querystring = {
+            "query": "fetch",
+            "collection": contract_address,
+            "taskId": "any",
+            "norm": "true",
+            "partial": "false",
+            "traitCount": "true",
+        }
+
+        response = requests.request(
+            "GET",
+            RARITY_SNIFFER_API_URL,
+            params=querystring,
+            headers=USER_AGENT,
+        )
+
+        if response.status_code != 200:
+            logger.debug(
+                "[RaritySniffer] Failed to resolve Rarity Sniffer ranks for "
+                f"{contract_address}. Received: {response.status_code}: "
+                f"{response.reason} {response.json()}"
+            )
+            response.raise_for_status()
+
+        data = response.json().get("data", None)
+        if "Not found" in response.json().get("error", "") or not data:
+            logger.exception(
+                f"[RaritySniffer] No data for {contract_address}. "
+                f"Json response: {response.json()}",
+                exc_info=True,
+            )
+            return {}
+        try:
+            token_ids_to_ranks = {
+                str(nft["id"]): int(nft["positionId"]) for nft in data
+            }
+        except Exception:
+            logger.exception(
+                f"[RaritySniffer] Data could not be parsed for {contract_address}. "
+                f"Json response: {response.json()}",
+                exc_info=True,
+            )
+            return {}
+
+        return token_ids_to_ranks

--- a/open_rarity/resolver/rarity_providers/rarity_sniffer.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniffer.py
@@ -15,7 +15,7 @@ USER_AGENT = {
 }
 
 
-class RaritySnifferProvider:
+class RaritySnifferResolver:
     @staticmethod
     def get_ranks(contract_address: str) -> dict[str, int]:
         """Fetches all available tokens and ranks

--- a/open_rarity/resolver/rarity_providers/rarity_sniffer.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniffer.py
@@ -19,7 +19,7 @@ USER_AGENT = {
 
 class RaritySnifferResolver(RankResolver):
     @staticmethod
-    def get_all_ranks(contract_address: str | None = None) -> dict[str, int]:
+    def get_all_ranks(contract_address: str) -> dict[str, int]:
         """Fetches all available tokens and ranks
         for a given collection from rarity sniffer.
         Only usable for EVM tokens and collections for a single
@@ -38,9 +38,6 @@ class RaritySnifferResolver(RankResolver):
         Exception
             If call to the rarity sniffer failed the method throws exception
         """
-        if contract_address is None:
-            raise ValueError("Contract address is required for Rarity Sniffer")
-
         querystring = {
             "query": "fetch",
             "collection": contract_address,

--- a/open_rarity/resolver/rarity_providers/rarity_sniffer.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniffer.py
@@ -2,6 +2,8 @@ import logging
 
 import requests
 
+from .rank_resolver import RankResolver
+
 logger = logging.getLogger("open_rarity_logger")
 RARITY_SNIFFER_API_URL = "https://raritysniffer.com/api/index.php"
 RARITY_SNIPER_API_URL = (
@@ -15,9 +17,9 @@ USER_AGENT = {
 }
 
 
-class RaritySnifferResolver:
+class RaritySnifferResolver(RankResolver):
     @staticmethod
-    def get_ranks(contract_address: str) -> dict[str, int]:
+    def get_all_ranks(contract_address: str | None = None) -> dict[str, int]:
         """Fetches all available tokens and ranks
         for a given collection from rarity sniffer.
         Only usable for EVM tokens and collections for a single
@@ -36,6 +38,8 @@ class RaritySnifferResolver:
         Exception
             If call to the rarity sniffer failed the method throws exception
         """
+        if contract_address is None:
+            raise ValueError("Contract address is required for Rarity Sniffer")
 
         querystring = {
             "query": "fetch",

--- a/open_rarity/resolver/rarity_providers/rarity_sniper.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniper.py
@@ -2,6 +2,8 @@ import logging
 
 import requests
 
+from .rank_resolver import RankResolver
+
 logger = logging.getLogger("open_rarity_logger")
 RARITY_SNIPER_API_URL = (
     "https://api.raritysniper.com/public/collection/{slug}/id/{token_id}"
@@ -11,7 +13,11 @@ USER_AGENT = {
 }
 
 
-class RaritySniperResolver:
+class RaritySniperResolver(RankResolver):
+    @staticmethod
+    def get_all_ranks(slug: str) -> dict[str, int]:
+        raise NotImplementedError
+
     @staticmethod
     def get_slug(opensea_slug: str) -> str:
         # custom fixes to normalize slug name

--- a/open_rarity/resolver/rarity_providers/rarity_sniper.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniper.py
@@ -11,7 +11,7 @@ USER_AGENT = {
 }
 
 
-class RaritySniperProvider:
+class RaritySniperResolver:
     @staticmethod
     def get_slug(opensea_slug: str) -> str:
         # custom fixes to normalize slug name

--- a/open_rarity/resolver/rarity_providers/rarity_sniper.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniper.py
@@ -1,0 +1,44 @@
+import logging
+
+import requests
+
+logger = logging.getLogger("open_rarity_logger")
+RARITY_SNIPER_API_URL = (
+    "https://api.raritysniper.com/public/collection/{slug}/id/{token_id}"
+)
+USER_AGENT = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"  # noqa: E501
+}
+
+
+class RaritySniperProvider:
+    @staticmethod
+    def get_slug(opensea_slug: str) -> str:
+        # custom fixes to normalize slug name
+        # used in rarity sniper
+        slug = opensea_slug.replace("-nft", "")
+        slug = slug.replace("-official", "")
+        slug = slug.replace("beanzofficial", "beanz")
+        slug = slug.replace("boredapeyachtclub", "bored-ape-yacht-club")
+        slug = slug.replace("clonex", "clone-x")
+        slug = slug.replace("invisiblefriends", "invisible-friends")
+        slug = slug.replace("proof-", "")
+        slug = slug.replace("pudgypenguins", "pudgy-penguins")
+        slug = slug.replace("wtf", "")
+
+        return slug
+
+    @staticmethod
+    def get_rank(collection_slug: str, token_id: int) -> int | None:
+        url = RARITY_SNIPER_API_URL.format(slug=collection_slug, token_id=token_id)
+        logger.debug("{url}".format(url=url))
+        response = requests.request("GET", url, headers=USER_AGENT)
+        if response.status_code == 200:
+            return response.json()["rank"]
+        else:
+            logger.debug(
+                f"[RaritySniper] Failed to resolve Rarity Sniper rank for "
+                f"{collection_slug} {token_id}. Received {response.status_code} for "
+                f"{url}: {response.reason}. {response.json()}"
+            )
+            return None

--- a/open_rarity/resolver/rarity_providers/trait_sniper.py
+++ b/open_rarity/resolver/rarity_providers/trait_sniper.py
@@ -1,0 +1,146 @@
+import logging
+import os
+import time
+
+import requests
+
+logger = logging.getLogger("open_rarity_logger")
+# For fetching rank fetches for an entire contract
+TRAIT_SNIPER_RANKS_URL = (
+    "https://api.traitsniper.com/v1/collections/{contract_address}/ranks"
+)
+# For single rank fetches
+TRAIT_SNIPER_NFTS_URL = "https://api.traitsniper.com/api/projects/{slug}/nfts"
+
+USER_AGENT = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"  # noqa: E501
+}
+API_KEY = os.environ.get("TRAIT_SNIPER_API_KEY") or ""
+
+
+class TraitSniperProvider:
+    @classmethod
+    def get_all_ranks(cls, contract_address: str) -> list[dict]:
+        rank_data = cls.get_ranks(contract_address, page=1)
+        all_rank_data = rank_data
+        page = 2
+
+        while rank_data:
+            rank_data = cls.get_ranks(contract_address, page=page)
+            all_rank_data.extend(rank_data)
+            page += 1
+            # Due to rate limits we need to slow things down a bit...
+            # Free tier is 5 request per second
+            time.sleep(12)
+
+        return all_rank_data
+
+    @staticmethod
+    def get_ranks(contract_address: str, page: int, limit: int = 200) -> list[dict]:
+        """
+        Parameters
+        ----------
+        contract_address: str
+            The contract address of collection you're fetching ranks for
+        limit: int
+            The number of ranks to fetch. Defaults to 200, and maxes at 200
+            due to API limitations.
+
+        Returns
+        -------
+            List of rarity rank data from trait sniper API with the following
+            data structure for each item in the list:
+            {
+                "rarity_rank": int,
+                "rarity_score": float
+                "token_id": str
+            }
+
+        Requires
+        --------
+            API KEY
+
+        Raises
+        ------
+            ValueError if contract address is None
+        """
+        if not contract_address:
+            msg = f"Failed to fetch traitsniper. {contract_address=} is invalid."
+            logger.exception(msg)
+            raise ValueError(msg)
+
+        url = TRAIT_SNIPER_RANKS_URL.format(contract_address=contract_address)
+        headers = {
+            **USER_AGENT,
+            **{"X-TS-API-KEY": API_KEY},
+        }
+        query_params = {
+            "limit": max(limit, 200),
+            "page": page,
+        }
+        response = requests.request("GET", url, headers=headers, params=query_params)
+        if response.status_code == 200:
+            return response.json()["ranks"]
+        else:
+            if (
+                "Collection could not be found on TraitSniper"
+                in response.json()["message"]
+            ):
+                logger.warning(
+                    f"[TraitSniper] Collection not found: {contract_address}"
+                )
+            else:
+                logger.debug(
+                    "[TraitSniper] Failed to resolve TraitSniper rank for "
+                    f"{contract_address}. Received {response.status_code} "
+                    f"for {url}: {response.reason}. {response.json()}"
+                )
+            return []
+
+    @staticmethod
+    def get_rank(collection_slug: str, token_id: int) -> int | None:
+        """Sends a GET request to Trait Sniper API to fetch ranking
+        data for a given EVM token. Trait Sniper uses opensea slug as a param.
+
+        Parameters
+        ----------
+        collection_slug : str
+            collection slug of collection you're attempting to fetch. This must be
+            the slug on trait sniper's slug system.
+        token_id : int
+            the token number.
+
+        Returns
+        -------
+        int | None
+            Rarity rank for given token ID if request was successful, otherwise None.
+
+        Raises
+        ------
+        ValueError
+            If slug is invalid.
+        """
+        # TODO [vicky]: In future, we can add retry mechanisms if needed
+
+        querystring = {
+            "trait_norm": "true",
+            "trait_count": "true",
+            "token_id": token_id,
+        }
+
+        if not collection_slug:
+            msg = "Cannot fetch traitsniper rank as slug is None."
+            logger.exception(msg)
+            raise ValueError(msg)
+
+        url = TRAIT_SNIPER_NFTS_URL.format(slug=collection_slug)
+        response = requests.request("GET", url, params=querystring, headers=USER_AGENT)
+        if response.status_code == 200:
+            return int(response.json()["nfts"][0]["rarity_rank"])
+        else:
+            logger.debug(
+                "[TraitSniper] Failed to resolve TraitSniper rank for "
+                f"{collection_slug} {token_id}. Received {response.status_code} "
+                f"for {url}: {response.reason}. {response.json()}"
+            )
+            return None

--- a/open_rarity/resolver/rarity_providers/trait_sniper.py
+++ b/open_rarity/resolver/rarity_providers/trait_sniper.py
@@ -45,7 +45,7 @@ class TraitSniperResolver(RankResolver):
             time.sleep(12)
 
         return {
-            str(rank_data["token_id"]): int(rank_data["rank"])
+            str(rank_data["token_id"]): int(rank_data["rarity_rank"])
             for rank_data in all_rank_data
         }
 

--- a/open_rarity/resolver/rarity_providers/trait_sniper.py
+++ b/open_rarity/resolver/rarity_providers/trait_sniper.py
@@ -30,8 +30,6 @@ class TraitSniperResolver(RankResolver):
         dict[str, int]
             A dictionary of token_id to ranks
         """
-        if contract_address is None:
-            raise ValueError("Contract address is required for Trait Sniper")
         rank_data_page = TraitSniperResolver.get_ranks(contract_address, page=1)
         all_rank_data = rank_data_page
         page = 2

--- a/open_rarity/resolver/rarity_providers/trait_sniper.py
+++ b/open_rarity/resolver/rarity_providers/trait_sniper.py
@@ -18,7 +18,7 @@ USER_AGENT = {
 API_KEY = os.environ.get("TRAIT_SNIPER_API_KEY") or ""
 
 
-class TraitSniperProvider:
+class TraitSniperResolver:
     @classmethod
     def get_all_ranks(cls, contract_address: str) -> list[dict]:
         rank_data = cls.get_ranks(contract_address, page=1)

--- a/open_rarity/resolver/testset_resolver.py
+++ b/open_rarity/resolver/testset_resolver.py
@@ -603,12 +603,12 @@ if __name__ == "__main__":
     on test collections. Data resolved from opensea api
 
     Command to run:
-    `python -m openrarity.resolver.testset_resolver external`
+    `python -m open_rarity.resolver.testset_resolver external`
 
         This will only produce ranks from OpenRarity and RaritySniffer by default.
 
     To run for all external providers:
-    `TRAIT_SNIPER_API_KEY=<your key> python -m openrarity.resolver.testset_resolver \
+    `TRAIT_SNIPER_API_KEY=<your key> python -m open_rarity.resolver.testset_resolver \
         external --trait_sniper --rarity_sniper`
     """
     args = parser.parse_args()
@@ -637,19 +637,21 @@ if __name__ == "__main__":
         "Welcome to OpenRarity resolver! This is a tool to view OpenRarity rankings \n"
         "for given collection(s) and to compare them with existing ranking \n"
         "providers. If you just want to output OpenRarity rankings, you can use "
-        "the script scripts/score_real_collections.py. \n For full options, "
+        "the script scripts/score_real_collections.py. \nFor full options, "
         "run `python3 -m open_rarity.resolver.testset_resolver --help`"
     )
     print(f"\nExecuting args: {args}")
     if resolve_remote_rarity:
-        print(f"Resolvers: {[rp.value for rp in external_resolvers]}")
+        print(
+            f"Fetching external ranks from: {[rp.value for rp in external_resolvers]}"
+        )
 
     print(
         "\nNOTE: Resolving external data can take awhile due to external API rate"
         "\nlimits. Local caching will occur automatically so that future runs of "
         "\nthe same collection can be efficient. Expect a 10k collection to take >5 min"
         "\nwithout local cached data (timing based on exact external resolver(s) set). "
-        "With caching, expect ~15 seconds for processing."
+        "\nWith caching, expect ~15 seconds for processing."
     )
 
     resolve_collection_data(

--- a/open_rarity/resolver/testset_resolver.py
+++ b/open_rarity/resolver/testset_resolver.py
@@ -198,12 +198,12 @@ def get_tokens_with_rarity(
         # Add the batch of augmented tokens with rarity into return value
         tokens_with_rarity.extend(tokens_rarity_batch)
 
-    # Cache the data
-    if cache_external_ranks:
-        for rank_provider in external_rank_providers:
-            external_rarity_provider.write_cache_to_file(
-                slug=slug, rank_provider=rank_provider
-            )
+    # Just write Rarity Sniper cache to file since the rest are bulk fetches
+    # and are already are auto cached post-fetch.
+    if cache_external_ranks and RankProvider.RARITY_SNIPER in external_rank_providers:
+        external_rarity_provider.write_cache_to_file(
+            slug=slug, rank_provider=RankProvider.RARITY_SNIPER
+        )
 
     t1_stop = time()
     logger.debug(

--- a/open_rarity/resolver/testset_resolver.py
+++ b/open_rarity/resolver/testset_resolver.py
@@ -79,6 +79,8 @@ parser.add_argument(
     default="test_collections.json",
     help="File in /data folder containing collections to resolve.",
 )
+
+# The fastest external rarity provider, taking <15 seconds to resolve all rank data.
 parser.add_argument(
     "--rarity_sniffer",
     dest="fetch_rarity_sniffer",
@@ -87,7 +89,8 @@ parser.add_argument(
     help="If external is specified, fetches rarity sniffer ranking data",
 )
 
-# NOTE: Default disabled due to API key requirements
+# Default disabled due to API key requirements. Without caching, this can take
+# ~10 minutes for a 10k collection due to rate limits.
 parser.add_argument(
     "--trait_sniper",
     dest="fetch_trait_sniper",
@@ -99,8 +102,8 @@ parser.add_argument(
     ),
 )
 
-# NOTE: Default disabled because no public bulk fetcher function and therefore
-# takes too long to fetch data for.
+# Default disabled because no public bulk fetcher function and therefore
+# takes a long to fetch data for.
 parser.add_argument(
     "--rarity_sniper",
     dest="fetch_rarity_sniper",

--- a/open_rarity/resolver/testset_resolver.py
+++ b/open_rarity/resolver/testset_resolver.py
@@ -103,7 +103,7 @@ parser.add_argument(
 )
 
 # Default disabled because no public bulk fetcher function and therefore
-# takes a long to fetch data for.
+# takes a long to fetch data for (~25 min for 10k collection).
 parser.add_argument(
     "--rarity_sniper",
     dest="fetch_rarity_sniper",
@@ -197,13 +197,6 @@ def get_tokens_with_rarity(
             )
         # Add the batch of augmented tokens with rarity into return value
         tokens_with_rarity.extend(tokens_rarity_batch)
-
-    # Just write Rarity Sniper cache to file since the rest are bulk fetches
-    # and are already are auto cached post-fetch.
-    if cache_external_ranks and RankProvider.RARITY_SNIPER in external_rank_providers:
-        external_rarity_provider.write_cache_to_file(
-            slug=slug, rank_provider=RankProvider.RARITY_SNIPER
-        )
 
     t1_stop = time()
     logger.debug(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Dan Meshkov <daniil.meshkov@opensea.io>", "Vicky Gong <vicky.gong@op
 description = "Open-Rarity library is an open standard that provides an easy, explanable and reproducible computation for NFT rarity"
 license = "Apache-2.0"
 name = "open-rarity"
-version = "0.6.0-beta"
+version = "0.6.1-beta"
 
 readme = "README.md"
 

--- a/tests/resolver/test_external_rarity_provider.py
+++ b/tests/resolver/test_external_rarity_provider.py
@@ -1,0 +1,68 @@
+import pytest
+
+from open_rarity.models.collection import Collection
+from open_rarity.models.token import Token
+from open_rarity.resolver.models.collection_with_metadata import CollectionWithMetadata
+from open_rarity.resolver.models.token_with_rarity_data import (
+    RankProvider,
+    TokenWithRarityData,
+)
+from open_rarity.resolver.rarity_providers.external_rarity_provider import (
+    ExternalRarityProvider,
+)
+
+
+class TestExternalRarityProvider:
+    bayc_address = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
+    bayc_collection = CollectionWithMetadata(
+        collection=Collection(tokens=[]),
+        contract_addresses=[bayc_address],
+        token_total_supply=10_000,
+        opensea_slug="boredapeyachtclub",
+    )
+    bayc_token_1 = Token.from_erc721(
+        contract_address=bayc_address,
+        token_id=1,
+        metadata_dict={
+            "mouth": "grin",
+            "background": "orange",
+            "eyes": "blue beams",
+            "fur": "robot",
+            "clothes": "vietnam jacket",
+        },
+    )
+
+    @pytest.mark.skipif(
+        "not config.getoption('--run-resolvers')",
+        reason="This tests runs too long due to rate limits to have as part of CI/CD "
+        "but should be run whenver someone changes resolvers. Also needs "
+        "TRAIT_SNIPER_API_KEY key",
+    )
+    def test_fetch_and_update_ranks_all_providers(self):
+        provider = ExternalRarityProvider()
+        tokens_with_rarity = [TokenWithRarityData(token=self.bayc_token_1, rarities=[])]
+        provider.fetch_and_update_ranks(
+            collection_with_metadata=self.bayc_collection,
+            tokens_with_rarity=tokens_with_rarity,
+            cache_external_ranks=False,
+        )
+        rarities = tokens_with_rarity[0].rarities
+        assert len(rarities) == 3
+
+    def test_fetch_and_update_ranks_rarity_sniffer_sniper(self):
+        provider = ExternalRarityProvider()
+        tokens_with_rarity = [TokenWithRarityData(token=self.bayc_token_1, rarities=[])]
+        provider.fetch_and_update_ranks(
+            collection_with_metadata=self.bayc_collection,
+            tokens_with_rarity=tokens_with_rarity,
+            cache_external_ranks=False,
+            rank_providers=[RankProvider.RARITY_SNIFFER, RankProvider.RARITY_SNIPER],
+        )
+        rarities = tokens_with_rarity[0].rarities
+        assert len(rarities) == 2
+        for rarity in rarities:
+            assert rarity.provider in [
+                RankProvider.RARITY_SNIFFER,
+                RankProvider.RARITY_SNIPER,
+            ]
+            assert rarity.rank

--- a/tests/resolver/test_rarity_sniffer.py
+++ b/tests/resolver/test_rarity_sniffer.py
@@ -1,15 +1,15 @@
-from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferProvider
+from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferResolver
 
 
-class TestRaritySnifferProvider:
+class TestRaritySnifferResolver:
     BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
 
     def test_get_ranks(self):
-        token_id_to_ranks = RaritySnifferProvider.get_ranks(
+        token_id_to_ranks = RaritySnifferResolver.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS
         )
         assert len(token_id_to_ranks) == 10_000
 
     def test_get_ranks_no_contract(self):
-        token_id_to_ranks = RaritySnifferProvider.get_ranks(contract_address="0x123")
+        token_id_to_ranks = RaritySnifferResolver.get_ranks(contract_address="0x123")
         assert len(token_id_to_ranks) == 0

--- a/tests/resolver/test_rarity_sniffer.py
+++ b/tests/resolver/test_rarity_sniffer.py
@@ -4,12 +4,14 @@ from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferRe
 class TestRaritySnifferResolver:
     BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
 
-    def test_get_ranks(self):
-        token_id_to_ranks = RaritySnifferResolver.get_ranks(
+    def test_get_all_ranks(self):
+        token_id_to_ranks = RaritySnifferResolver.get_all_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS
         )
         assert len(token_id_to_ranks) == 10_000
 
-    def test_get_ranks_no_contract(self):
-        token_id_to_ranks = RaritySnifferResolver.get_ranks(contract_address="0x123")
+    def test_get_all_ranks_no_contract(self):
+        token_id_to_ranks = RaritySnifferResolver.get_all_ranks(
+            contract_address="0x123"
+        )
         assert len(token_id_to_ranks) == 0

--- a/tests/resolver/test_rarity_sniffer.py
+++ b/tests/resolver/test_rarity_sniffer.py
@@ -1,3 +1,4 @@
+from open_rarity.resolver.rarity_providers.rank_resolver import RankResolver
 from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferResolver
 
 
@@ -15,3 +16,6 @@ class TestRaritySnifferResolver:
             contract_address="0x123"
         )
         assert len(token_id_to_ranks) == 0
+
+    def test_rank_resolver_parent(self):
+        assert isinstance(RaritySnifferResolver, RankResolver)

--- a/tests/resolver/test_rarity_sniffer.py
+++ b/tests/resolver/test_rarity_sniffer.py
@@ -1,0 +1,15 @@
+from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferProvider
+
+
+class TestRaritySnifferProvider:
+    BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
+
+    def test_get_ranks(self):
+        token_id_to_ranks = RaritySnifferProvider.get_ranks(
+            contract_address=self.BORED_APE_COLLECTION_ADDRESS
+        )
+        assert len(token_id_to_ranks) == 10_000
+
+    def test_get_ranks_no_contract(self):
+        token_id_to_ranks = RaritySnifferProvider.get_ranks(contract_address="0x123")
+        assert len(token_id_to_ranks) == 0

--- a/tests/resolver/test_rarity_sniper.py
+++ b/tests/resolver/test_rarity_sniper.py
@@ -1,0 +1,19 @@
+from open_rarity.resolver.rarity_providers.rarity_sniper import RaritySniperProvider
+
+
+class TestRaritySniperProvider:
+    BORED_APE_SLUG = "bored-ape-yacht-club"
+
+    def test_get_rank(self):
+        rank = RaritySniperProvider.get_rank(
+            collection_slug=self.BORED_APE_SLUG,
+            token_id=1020,
+        )
+        # We don't check ranks since they can change ranks
+        assert rank
+
+    def test_get_rank_no_contract(self):
+        rank = RaritySniperProvider.get_rank(
+            collection_slug="non_existent_slug", token_id=1
+        )
+        assert rank is None

--- a/tests/resolver/test_rarity_sniper.py
+++ b/tests/resolver/test_rarity_sniper.py
@@ -1,3 +1,4 @@
+from open_rarity.resolver.rarity_providers.rank_resolver import RankResolver
 from open_rarity.resolver.rarity_providers.rarity_sniper import RaritySniperResolver
 
 
@@ -17,3 +18,6 @@ class TestRaritySniperResolver:
             collection_slug="non_existent_slug", token_id=1
         )
         assert rank is None
+
+    def test_rank_resolver_parent(self):
+        assert isinstance(RaritySniperResolver, RankResolver)

--- a/tests/resolver/test_rarity_sniper.py
+++ b/tests/resolver/test_rarity_sniper.py
@@ -1,11 +1,11 @@
-from open_rarity.resolver.rarity_providers.rarity_sniper import RaritySniperProvider
+from open_rarity.resolver.rarity_providers.rarity_sniper import RaritySniperResolver
 
 
-class TestRaritySniperProvider:
+class TestRaritySniperResolver:
     BORED_APE_SLUG = "bored-ape-yacht-club"
 
     def test_get_rank(self):
-        rank = RaritySniperProvider.get_rank(
+        rank = RaritySniperResolver.get_rank(
             collection_slug=self.BORED_APE_SLUG,
             token_id=1020,
         )
@@ -13,7 +13,7 @@ class TestRaritySniperProvider:
         assert rank
 
     def test_get_rank_no_contract(self):
-        rank = RaritySniperProvider.get_rank(
+        rank = RaritySniperResolver.get_rank(
             collection_slug="non_existent_slug", token_id=1
         )
         assert rank is None

--- a/tests/resolver/test_trait_sniper.py
+++ b/tests/resolver/test_trait_sniper.py
@@ -2,6 +2,8 @@ import pytest
 
 from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperProvider
 
+# NOTE: API_KEY is needed for these tests (TRAIT_SNIPER_API_KEY must be set)
+
 
 class TestTraitSniperProvider:
     BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
@@ -9,7 +11,7 @@ class TestTraitSniperProvider:
     @pytest.mark.skipif(
         "not config.getoption('--run-resolvers')",
         reason="This tests runs too long due to rate limits to have as part of CI/CD "
-        "but should be run whenver someone changes resolvers",
+        "but should be run whenver someone changes resolvers. Also needs API key",
     )
     def test_get_all_ranks(self):
         token_ranks = TraitSniperProvider.get_all_ranks(
@@ -17,11 +19,21 @@ class TestTraitSniperProvider:
         )
         assert len(token_ranks) == 10000
 
-    def test_get_ranks(self):
+    @pytest.mark.skipif(
+        "not config.getoption('--run-resolvers')",
+        reason="This requires API key",
+    )
+    def test_get_ranks_first_page(self):
         token_ranks = TraitSniperProvider.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=1
         )
         assert len(token_ranks) == 200
+
+    @pytest.mark.skipif(
+        "not config.getoption('--run-resolvers')",
+        reason="This requires API key",
+    )
+    def test_get_ranks_max_page(self):
         token_ranks = TraitSniperProvider.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=50
         )

--- a/tests/resolver/test_trait_sniper.py
+++ b/tests/resolver/test_trait_sniper.py
@@ -1,5 +1,6 @@
 import pytest
 
+from open_rarity.resolver.rarity_providers.rank_resolver import RankResolver
 from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperResolver
 
 # NOTE: API_KEY is needed for these tests (TRAIT_SNIPER_API_KEY must be set)
@@ -55,3 +56,6 @@ class TestTraitSniperResolver:
             token_id=1000,
         )
         assert rank
+
+    def test_rank_resolver_parent(self):
+        assert isinstance(TraitSniperResolver, RankResolver)

--- a/tests/resolver/test_trait_sniper.py
+++ b/tests/resolver/test_trait_sniper.py
@@ -1,11 +1,11 @@
 import pytest
 
-from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperProvider
+from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperResolver
 
 # NOTE: API_KEY is needed for these tests (TRAIT_SNIPER_API_KEY must be set)
 
 
-class TestTraitSniperProvider:
+class TestTraitSniperResolver:
     BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
 
     @pytest.mark.skipif(
@@ -14,7 +14,7 @@ class TestTraitSniperProvider:
         "but should be run whenver someone changes resolvers. Also needs API key",
     )
     def test_get_all_ranks(self):
-        token_ranks = TraitSniperProvider.get_all_ranks(
+        token_ranks = TraitSniperResolver.get_all_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS
         )
         assert len(token_ranks) == 10000
@@ -24,7 +24,7 @@ class TestTraitSniperProvider:
         reason="This requires API key",
     )
     def test_get_ranks_first_page(self):
-        token_ranks = TraitSniperProvider.get_ranks(
+        token_ranks = TraitSniperResolver.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=1
         )
         assert len(token_ranks) == 200
@@ -34,23 +34,23 @@ class TestTraitSniperProvider:
         reason="This requires API key",
     )
     def test_get_ranks_max_page(self):
-        token_ranks = TraitSniperProvider.get_ranks(
+        token_ranks = TraitSniperResolver.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=50
         )
         assert len(token_ranks) == 200
 
     def test_get_ranks_no_more_data(self):
-        token_ranks = TraitSniperProvider.get_ranks(
+        token_ranks = TraitSniperResolver.get_ranks(
             contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=51
         )
         assert len(token_ranks) == 0
 
     def test_get_ranks_no_contract(self):
-        token_ranks = TraitSniperProvider.get_ranks(contract_address="0x123", page=1)
+        token_ranks = TraitSniperResolver.get_ranks(contract_address="0x123", page=1)
         assert len(token_ranks) == 0
 
     def test_get_rank(self):
-        rank = TraitSniperProvider.get_rank(
+        rank = TraitSniperResolver.get_rank(
             collection_slug="boredapeyachtclub",
             token_id=1000,
         )

--- a/tests/resolver/test_trait_sniper.py
+++ b/tests/resolver/test_trait_sniper.py
@@ -1,0 +1,45 @@
+import pytest
+
+from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperProvider
+
+
+class TestTraitSniperProvider:
+    BORED_APE_COLLECTION_ADDRESS = "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"
+
+    @pytest.mark.skipif(
+        "not config.getoption('--run-resolvers')",
+        reason="This tests runs too long due to rate limits to have as part of CI/CD "
+        "but should be run whenver someone changes resolvers",
+    )
+    def test_get_all_ranks(self):
+        token_ranks = TraitSniperProvider.get_all_ranks(
+            contract_address=self.BORED_APE_COLLECTION_ADDRESS
+        )
+        assert len(token_ranks) == 10000
+
+    def test_get_ranks(self):
+        token_ranks = TraitSniperProvider.get_ranks(
+            contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=1
+        )
+        assert len(token_ranks) == 200
+        token_ranks = TraitSniperProvider.get_ranks(
+            contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=50
+        )
+        assert len(token_ranks) == 200
+
+    def test_get_ranks_no_more_data(self):
+        token_ranks = TraitSniperProvider.get_ranks(
+            contract_address=self.BORED_APE_COLLECTION_ADDRESS, page=51
+        )
+        assert len(token_ranks) == 0
+
+    def test_get_ranks_no_contract(self):
+        token_ranks = TraitSniperProvider.get_ranks(contract_address="0x123", page=1)
+        assert len(token_ranks) == 0
+
+    def test_get_rank(self):
+        rank = TraitSniperProvider.get_rank(
+            collection_slug="boredapeyachtclub",
+            token_id=1000,
+        )
+        assert rank


### PR DESCRIPTION
1. Having intermittent issues with external resolvers causing the entire script to fail
   - Fix: to catch errors and skip resolver if that specific resolver is having issues (or that external provider doesn't have data for that collection, which has happened)
2. Put all the external ranking provider fetchers into its own file for easier debugging/ bug fixing
   - Created resolver classes, `TraitSniperResolver`, `RaritySnifferResolver`, etc.
   - Note: The file structure needs some refactoring but would be a breaking change + super hard to review so leaving that for a separate PR.
   - Note 2: Technically removing helper methods from external_rarity_provider.py to individual files but don't believe it warrants a breaking change version upgrade since external rarity helper fetchers is not meant to be part of core library but used for debugging and data analysis.
3. Added unit tests for each provider
4. Added new TraitSniper bulk get ranks API support
5. Changed default resolver script to only fetch rarity sniffer, with optional flags to fetch the others (trait sniper, rarity sniper)
6. Added better description/output for resolver 
  - Example:
```
Welcome to OpenRarity resolver! This is a tool to view OpenRarity rankings 
for given collection(s) and to compare them with existing ranking 
providers. If you just want to output OpenRarity rankings, you can use the script scripts/score_real_collections.py. 
 For full options, run `python3 -m open_rarity.resolver.testset_resolver --help`

Executing args: Namespace(resolve_external_rarity='external', cache_fetched_data=True, filename='test_collections.json', fetch_rarity_sniffer=True, fetch_trait_sniper=False, fetch_rarity_sniper=True)
Resolvers: ['rarity_sniffer', 'rarity_sniper']

NOTE: Resolving external data can take awhile due to external API rate
limits. Local caching will occur automatically so that future runs of 
the same collection can be efficient. Expect a 10k collection to take >5 min
without local cached data (timing based on exact external resolver(s) set). With caching, expect ~15 seconds for processing.
------------------------------

BEGIN: Resolving collection doodles-official
1. Fetching collection & token traits for: doodles-official from opensea.
2. Fetching external rarity ranks for: doodles-official
...
```