### PR TITLE
Adding Meta Trait: Trait Count

### DIFF
--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -11,6 +11,8 @@ from open_rarity.models.token_metadata import (
 from open_rarity.models.token_standard import TokenStandard
 from open_rarity.models.utils.attribute_utils import normalize_attribute_string
 
+TRAIT_COUNT_ATTRIBUTE_NAME = "meta trait: trait_count"
+
 
 @dataclass
 class CollectionAttribute:
@@ -66,23 +68,24 @@ class Collection:
     attributes_frequency_counts: dict[AttributeName, dict[AttributeValue, int]]
     name: str
 
+    # TODO [vicky]: We should deprecate taking in attributes_frequency_counts
+    # as there can be divergence between the tokens and the attributes_frequency_counts.
+    # We should instead just take in tokens and compute the attributes_frequency_counts
+    # all the time.
     def __init__(
         self,
         tokens: list[Token],
+        # Deprecated - Kept to not break interface, but is not used.
         attributes_frequency_counts: dict[AttributeName, dict[AttributeValue, int]]
         | None = None,
         name: str | None = "",
     ):
+        self._trait_countify(tokens)
         self._tokens = tokens
         self.name = name or ""
-        if attributes_frequency_counts:
-            self.attributes_frequency_counts = (
-                self._normalize_attributes_frequency_counts(attributes_frequency_counts)
-            )
-        else:
-            self.attributes_frequency_counts = (
-                self._derive_normalized_attributes_frequency_counts()
-            )
+        self.attributes_frequency_counts = (
+            self._derive_normalized_attributes_frequency_counts()
+        )
 
     @property
     def tokens(self) -> list[Token]:
@@ -200,6 +203,31 @@ class Collection:
                 )
 
         return collection_traits
+
+    def _trait_countify(self, tokens: list[Token]) -> None:
+        """Updates tokens to have meta attribute "meta trait: trait_count" if it doesn't
+        already exist.
+
+        Parameters
+        ----------
+        tokens : list[Token]
+            List of tokens to add trait count attribute to. Modifies in place.
+
+        """
+        for token in tokens:
+            trait_count = token.trait_count()
+            if token.has_attribute(TRAIT_COUNT_ATTRIBUTE_NAME):
+                trait_count -= 1
+            # NOTE: There is a chance we override an existing attribute here, but it's
+            # highly unlikely that a token would have a trait_count attribute to begin
+            # with (no known collections have it right now).
+            # To decrease the chance of collision, we pre-pend "meta trait: ".
+            # If an existing trait count attribute already exists with a different name,
+            # we will not remove it. In the future, we can refactor to distinguish
+            # between meta and non-meta attributes.
+            token.metadata.add_attribute(
+                StringAttribute(name=TRAIT_COUNT_ATTRIBUTE_NAME, value=str(trait_count))
+            )
 
     def _normalize_attributes_frequency_counts(
         self,

--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -69,14 +69,13 @@ class Collection:
     attributes_frequency_counts: dict[AttributeName, dict[AttributeValue, int]]
     name: str
 
-    # TODO [vicky]: We should deprecate taking in attributes_frequency_counts
-    # as there can be divergence between the tokens and the attributes_frequency_counts.
-    # We should instead just take in tokens and compute the attributes_frequency_counts
-    # all the time.
     def __init__(
         self,
         tokens: list[Token],
         # Deprecated - Kept to not break interface, but is not used.
+        # We always coimpute the attributes_frequency_counts from the tokens to avoid
+        # divergence.
+        # TODO [10/16/22]: To remove in 1.0 release
         attributes_frequency_counts: dict[AttributeName, dict[AttributeValue, int]]
         | None = None,
         name: str | None = "",

--- a/open_rarity/models/collection.py
+++ b/open_rarity/models/collection.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
@@ -11,7 +12,7 @@ from open_rarity.models.token_metadata import (
 from open_rarity.models.token_standard import TokenStandard
 from open_rarity.models.utils.attribute_utils import normalize_attribute_string
 
-TRAIT_COUNT_ATTRIBUTE_NAME = "meta trait: trait_count"
+TRAIT_COUNT_ATTRIBUTE_NAME = "meta_trait:trait_count"
 
 
 @dataclass
@@ -80,6 +81,13 @@ class Collection:
         | None = None,
         name: str | None = "",
     ):
+        if attributes_frequency_counts is not None:
+            warnings.warn(
+                "`attribute_frequency_counts` is deprecated and will be removed. "
+                "Counts will be derived from the token data.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._trait_countify(tokens)
         self._tokens = tokens
         self.name = name or ""

--- a/open_rarity/models/token.py
+++ b/open_rarity/models/token.py
@@ -7,8 +7,14 @@ from open_rarity.models.token_identifier import (
     TokenIdentifier,
     get_identifier_class_from_dict,
 )
-from open_rarity.models.token_metadata import AttributeName, TokenMetadata
+from open_rarity.models.token_metadata import (
+    Attribute,
+    AttributeName,
+    StringAttribute,
+    TokenMetadata,
+)
 from open_rarity.models.token_standard import TokenStandard
+from open_rarity.models.utils.attribute_utils import normalize_attribute_string
 
 
 @dataclass
@@ -112,6 +118,33 @@ class Token:
 
     def attributes(self) -> dict[AttributeName, Any]:
         return self.metadata.to_attributes()
+
+    def has_attribute(self, attribute_name: str) -> bool:
+        return self.metadata.attribute_exists(attribute_name)
+
+    def trait_count(self) -> int:
+        """Returns the count of non-null, non-"none" value traits this token has."""
+        # TODO [vicky] In opensea and perhaps other sites, we return
+        # none as explicit empty traits. Do we want to explicitly filter
+        # out in this library or do it on opensea/provider side?
+        # Would love people's thoughts! Can see argument to not filter, and
+        # leaning towards that direction.
+        def get_attributes_count(attributes: list[Attribute]) -> int:
+            return sum(
+                map(
+                    lambda a: (
+                        not isinstance(a, StringAttribute)
+                        or normalize_attribute_string(a.value) not in ("none", "")
+                    ),
+                    attributes,
+                )
+            )
+
+        return (
+            get_attributes_count(self.metadata.string_attributes.values())
+            + get_attributes_count(self.metadata.numeric_attributes.values())
+            + get_attributes_count(self.metadata.date_attributes.values())
+        )
 
     def to_dict(self) -> dict:
         return {

--- a/open_rarity/models/token.py
+++ b/open_rarity/models/token.py
@@ -124,11 +124,7 @@ class Token:
 
     def trait_count(self) -> int:
         """Returns the count of non-null, non-"none" value traits this token has."""
-        # TODO [vicky] In opensea and perhaps other sites, we return
-        # none as explicit empty traits. Do we want to explicitly filter
-        # out in this library or do it on opensea/provider side?
-        # Would love people's thoughts! Can see argument to not filter, and
-        # leaning towards that direction.
+
         def get_attributes_count(attributes: list[Attribute]) -> int:
             return sum(
                 map(

--- a/open_rarity/models/token_metadata.py
+++ b/open_rarity/models/token_metadata.py
@@ -110,19 +110,6 @@ class TokenMetadata:
         )
         self.date_attributes = self._normalize_attributes_dict(self.date_attributes)
 
-    def _normalize_attributes_dict(self, attributes_dict: dict) -> dict:
-        """Helper function that takes in an attributes dictionary
-        and normalizes attribute name in the dictionary to ensure all
-        letters are lower cases and whitespace is stripped.
-        """
-        normalized_attributes_dict = {}
-        for attribute_name, attr in attributes_dict.items():
-            normalized_attr_name = normalize_attribute_string(attribute_name)
-            normalized_attributes_dict[normalized_attr_name] = attr
-            if normalized_attr_name != attr.name:
-                attr.name = normalized_attr_name
-        return normalized_attributes_dict
-
     @classmethod
     def from_attributes(cls, attributes: dict[AttributeName, Any]):
         """Constructs TokenMetadata class based on an attributes dictionary
@@ -184,3 +171,40 @@ class TokenMetadata:
         for attr in self.date_attributes.values():
             attributes[attr.name] = datetime.fromtimestamp(attr.value)
         return attributes
+
+    def add_attribute(self, attribute: Attribute):
+        """Adds an attribute to this metadata object, overriding existing
+        attribute if the normalized attribute name already exists."""
+        if isinstance(attribute, StringAttribute):
+            self.string_attributes[attribute.name] = attribute
+        elif isinstance(attribute, NumericAttribute):
+            self.numeric_attributes[attribute.name] = attribute
+        elif isinstance(attribute, DateAttribute):
+            self.date_attributes[attribute.name] = attribute
+        else:
+            raise TypeError(
+                f"Provided attribute has invalid type: {type(attribute)}. "
+                "Must be either StringAttribute, NumericAttribute or DateAttribute."
+            )
+
+    def attribute_exists(self, attribute_name: str) -> bool:
+        """Returns True if this metadata object has an attribute with the given name."""
+        attr_name = normalize_attribute_string(attribute_name)
+        return (
+            attr_name in self.string_attributes
+            or attr_name in self.numeric_attributes
+            or attr_name in self.date_attributes
+        )
+
+    def _normalize_attributes_dict(self, attributes_dict: dict) -> dict:
+        """Helper function that takes in an attributes dictionary
+        and normalizes attribute name in the dictionary to ensure all
+        letters are lower cases and whitespace is stripped.
+        """
+        normalized_attributes_dict = {}
+        for attribute_name, attr in attributes_dict.items():
+            normalized_attr_name = normalize_attribute_string(attribute_name)
+            normalized_attributes_dict[normalized_attr_name] = attr
+            if normalized_attr_name != attr.name:
+                attr.name = normalized_attr_name
+        return normalized_attributes_dict

--- a/open_rarity/rarity_ranker.py
+++ b/open_rarity/rarity_ranker.py
@@ -109,15 +109,15 @@ class RarityRanker:
             reverse=True,
         )
 
-        # perform ranking of each token in collection
-        for i, token in enumerate(sorted_token_rarities):
+        # Perform ranking of each token in collection
+        for i, token_rarity in enumerate(sorted_token_rarities):
             rank = i + 1
             if i > 0:
-                prev_token = sorted_token_rarities[i - 1]
-                scores_equal = math.isclose(token.score, prev_token.score)
+                prev_token_rarity = sorted_token_rarities[i - 1]
+                scores_equal = math.isclose(token_rarity.score, prev_token_rarity.score)
                 if scores_equal:
-                    rank = prev_token.rank
+                    rank = prev_token_rarity.rank
 
-            token.rank = rank
+            token_rarity.rank = rank
 
         return sorted_token_rarities

--- a/open_rarity/resolver/rarity_providers/rarity_sniffer.py
+++ b/open_rarity/resolver/rarity_providers/rarity_sniffer.py
@@ -6,9 +6,6 @@ from .rank_resolver import RankResolver
 
 logger = logging.getLogger("open_rarity_logger")
 RARITY_SNIFFER_API_URL = "https://raritysniffer.com/api/index.php"
-RARITY_SNIPER_API_URL = (
-    "https://api.raritysniper.com/public/collection/{slug}/id/{token_id}"
-)
 USER_AGENT = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "

--- a/open_rarity/scoring/handlers/arithmetic_mean_scoring_handler.py
+++ b/open_rarity/scoring/handlers/arithmetic_mean_scoring_handler.py
@@ -1,13 +1,9 @@
-import logging
-
 import numpy as np
 
 from open_rarity.models.collection import Collection, CollectionAttribute
 from open_rarity.models.token import Token
 from open_rarity.models.token_metadata import AttributeName
 from open_rarity.scoring.utils import get_token_attributes_scores_and_weights
-
-logger = logging.getLogger("open_rarity_logger")
 
 
 class ArithmeticMeanScoringHandler:
@@ -69,21 +65,11 @@ class ArithmeticMeanScoringHandler:
         float
             The token score
         """
-        logger.debug("Computing arithmetic mean for token %s", token)
-
         attr_scores, attr_weights = get_token_attributes_scores_and_weights(
             collection=collection,
             token=token,
             normalized=normalized,
             collection_null_attributes=collection_null_attributes,
-        )
-
-        logger.debug(
-            "[amean] Calculated for %s %s:%s %s",
-            collection,
-            token,
-            attr_scores,
-            attr_weights,
         )
 
         avg = float(np.average(attr_scores, weights=attr_weights))

--- a/open_rarity/scoring/handlers/geometric_mean_scoring_handler.py
+++ b/open_rarity/scoring/handlers/geometric_mean_scoring_handler.py
@@ -1,13 +1,9 @@
-import logging
-
 import scipy.stats
 
 from open_rarity.models.collection import Collection, CollectionAttribute
 from open_rarity.models.token import Token
 from open_rarity.models.token_metadata import AttributeName
 from open_rarity.scoring.utils import get_token_attributes_scores_and_weights
-
-logger = logging.getLogger("open_rarity_logger")
 
 
 class GeometricMeanScoringHandler:
@@ -72,8 +68,6 @@ class GeometricMeanScoringHandler:
         float
             The token score
         """
-        logger.debug(f"Computing geometric mean for {collection} token {token}")
-
         attr_scores, attr_weights = get_token_attributes_scores_and_weights(
             collection=collection,
             token=token,

--- a/open_rarity/scoring/handlers/harmonic_mean_scoring_handler.py
+++ b/open_rarity/scoring/handlers/harmonic_mean_scoring_handler.py
@@ -1,13 +1,9 @@
-import logging
-
 import numpy as np
 
 from open_rarity.models.collection import Collection, CollectionAttribute
 from open_rarity.models.token import Token
 from open_rarity.models.token_metadata import AttributeName
 from open_rarity.scoring.utils import get_token_attributes_scores_and_weights
-
-logger = logging.getLogger("open_rarity_logger")
 
 
 class HarmonicMeanScoringHandler:
@@ -70,7 +66,6 @@ class HarmonicMeanScoringHandler:
         float
             The token score
         """
-        logger.debug(f"Computing Harmonic mean for token {token}")
 
         attr_scores, attr_weights = get_token_attributes_scores_and_weights(
             collection=collection,

--- a/open_rarity/scoring/handlers/information_content_scoring_handler.py
+++ b/open_rarity/scoring/handlers/information_content_scoring_handler.py
@@ -116,19 +116,9 @@ class InformationContentScoringHandler:
         """
         logger.debug("Computing score for token %s", token)
 
-        # First calculate the individual attribute scores for all attributes
-        # of the provided token. Scores are the inverted probabilities of the
-        # attribute in the collection.
-        attr_scores, _ = get_token_attributes_scores_and_weights(
-            collection=collection,
-            token=token,
-            normalized=False,
-            collection_null_attributes=collection_null_attributes,
+        ic_token_score = self._get_ic_score(
+            collection, token, collection_null_attributes=collection_null_attributes
         )
-
-        # Get a single score (via information content) for the token by taking
-        # the sum of the logarithms of the attributes' scores.
-        ic_token_score = -np.sum(np.log2(np.reciprocal(attr_scores)))
         logger.debug("IC token score %s", ic_token_score)
 
         # Now, calculate the collection entropy to use as a normalization for
@@ -151,6 +141,26 @@ class InformationContentScoringHandler:
         )
 
         return normalized_token_score
+
+    def _get_ic_score(
+        self,
+        collection: Collection,
+        token: Token,
+        collection_null_attributes: dict[AttributeName, CollectionAttribute] = None,
+    ) -> float:
+        # First calculate the individual attribute scores for all attributes
+        # of the provided token. Scores are the inverted probabilities of the
+        # attribute in the collection.
+        attr_scores, _ = get_token_attributes_scores_and_weights(
+            collection=collection,
+            token=token,
+            normalized=False,
+            collection_null_attributes=collection_null_attributes,
+        )
+
+        # Get a single score (via information content) for the token by taking
+        # the sum of the logarithms of the attributes' scores.
+        return -np.sum(np.log2(np.reciprocal(attr_scores)))
 
     def _get_collection_entropy(
         self,

--- a/open_rarity/scoring/handlers/sum_scoring_handler.py
+++ b/open_rarity/scoring/handlers/sum_scoring_handler.py
@@ -1,13 +1,9 @@
-import logging
-
 import numpy as np
 
 from open_rarity.models.collection import Collection, CollectionAttribute
 from open_rarity.models.token import Token
 from open_rarity.models.token_metadata import AttributeName
 from open_rarity.scoring.utils import get_token_attributes_scores_and_weights
-
-logger = logging.getLogger("open_rarity_logger")
 
 
 class SumScoringHandler:
@@ -70,8 +66,6 @@ class SumScoringHandler:
         float
             The token score
         """
-        logger.debug(f"Computing sum score for token {token}")
-
         attr_scores, attr_weights = get_token_attributes_scores_and_weights(
             collection=collection,
             token=token,

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,11 +14,11 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "black"
-version = "22.8.0"
+version = "22.10.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7"
 
 [package.dependencies]
 click = ">=8.0.0"
@@ -35,7 +35,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15.1"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -81,7 +81,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.4"
+version = "6.5.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -128,7 +128,7 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "flake8-bugbear"
-version = "22.8.23"
+version = "22.9.23"
 description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 category = "dev"
 optional = false
@@ -143,7 +143,7 @@ dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
 
 [[package]]
 name = "identify"
-version = "2.5.5"
+version = "2.5.6"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -154,7 +154,7 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -226,7 +226,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*
 
 [[package]]
 name = "numpy"
-version = "1.23.3"
+version = "1.23.4"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -245,7 +245,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.4.4"
+version = "1.5.0"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -257,7 +257,7 @@ python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
 
 [[package]]
 name = "pathspec"
@@ -299,8 +299,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -401,7 +401,21 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "python-dateutil"
@@ -416,7 +430,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.2.1"
+version = "2022.4"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -450,14 +464,19 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "scipy"
-version = "1.9.1"
-description = "SciPy: Scientific Library for Python"
+version = "1.9.2"
+description = "Fundamental algorithms for scientific computing in Python"
 category = "main"
 optional = false
-python-versions = ">=3.8,<3.12"
+python-versions = ">=3.8"
 
 [package.dependencies]
-numpy = ">=1.18.5,<1.25.0"
+numpy = ">=1.18.5,<1.26.0"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-xdist", "asv", "mpmath", "gmpy2", "threadpoolctl", "scikit-umfpack"]
+doc = ["sphinx (!=4.1.0)", "pydata-sphinx-theme (==0.9.0)", "sphinx-panels (>=0.5.2)", "matplotlib (>2)", "numpydoc", "sphinx-tabs"]
+dev = ["mypy", "typing-extensions", "pycodestyle", "flake8"]
 
 [[package]]
 name = "six"
@@ -485,7 +504,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "types-requests"
-version = "2.28.10"
+version = "2.28.11.2"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -496,7 +515,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.24"
+version = "1.26.25"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -504,7 +523,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -543,54 +562,374 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "be06b05e90d12f4287b6a38cc9c31882e2853b995edd0f6b60f411ad238f77b9"
+content-hash = "f1955f434379687b2b4d725bdb8eef1100b5ff8c43a1c17e3366e590b6bf6ad0"
 
 [metadata.files]
 attrs = []
-black = []
-certifi = []
-cfgv = []
-charset-normalizer = []
+black = [
+    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
+    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
+    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
+    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
+    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
+    {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
+    {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
+    {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
+    {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
+    {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
+    {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
+    {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
+    {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
+    {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
+    {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
+    {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
+    {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
+]
+certifi = [
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
+]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
+]
 click = []
 colorama = []
-coverage = []
-distlib = []
-filelock = []
-flake8 = []
-flake8-bugbear = []
-identify = []
-idna = []
-iniconfig = []
-isort = []
-mccabe = []
+coverage = [
+    {file = "coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53"},
+    {file = "coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a"},
+    {file = "coverage-6.5.0-cp310-cp310-win32.whl", hash = "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32"},
+    {file = "coverage-6.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e"},
+    {file = "coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b"},
+    {file = "coverage-6.5.0-cp311-cp311-win32.whl", hash = "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578"},
+    {file = "coverage-6.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b"},
+    {file = "coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f"},
+    {file = "coverage-6.5.0-cp37-cp37m-win32.whl", hash = "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b"},
+    {file = "coverage-6.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e"},
+    {file = "coverage-6.5.0-cp38-cp38-win32.whl", hash = "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d"},
+    {file = "coverage-6.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f"},
+    {file = "coverage-6.5.0-cp39-cp39-win32.whl", hash = "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72"},
+    {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
+    {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
+    {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
+]
+distlib = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+filelock = [
+    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
+    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
+]
+flake8 = [
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+]
+flake8-bugbear = [
+    {file = "flake8-bugbear-22.9.23.tar.gz", hash = "sha256:17b9623325e6e0dcdcc80ed9e4aa811287fcc81d7e03313b8736ea5733759937"},
+    {file = "flake8_bugbear-22.9.23-py3-none-any.whl", hash = "sha256:cd2779b2b7ada212d7a322814a1e5651f1868ab0d3f24cc9da66169ab8fda474"},
+]
+identify = [
+    {file = "identify-2.5.6-py2.py3-none-any.whl", hash = "sha256:b276db7ec52d7e89f5bc4653380e33054ddc803d25875952ad90b0f012cbcdaa"},
+    {file = "identify-2.5.6.tar.gz", hash = "sha256:6c32dbd747aa4ceee1df33f25fed0b0f6e0d65721b15bd151307ff7056d50245"},
+]
+idna = [
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
 mypy = []
-mypy-extensions = []
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 nodeenv = []
-numpy = []
-packaging = []
-pandas = []
-pathspec = []
-pep8-naming = []
-platformdirs = []
-pluggy = []
+numpy = [
+    {file = "numpy-1.23.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:95d79ada05005f6f4f337d3bb9de8a7774f259341c70bc88047a1f7b96a4bcb2"},
+    {file = "numpy-1.23.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:926db372bc4ac1edf81cfb6c59e2a881606b409ddc0d0920b988174b2e2a767f"},
+    {file = "numpy-1.23.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c237129f0e732885c9a6076a537e974160482eab8f10db6292e92154d4c67d71"},
+    {file = "numpy-1.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8365b942f9c1a7d0f0dc974747d99dd0a0cdfc5949a33119caf05cb314682d3"},
+    {file = "numpy-1.23.4-cp310-cp310-win32.whl", hash = "sha256:2341f4ab6dba0834b685cce16dad5f9b6606ea8a00e6da154f5dbded70fdc4dd"},
+    {file = "numpy-1.23.4-cp310-cp310-win_amd64.whl", hash = "sha256:d331afac87c92373826af83d2b2b435f57b17a5c74e6268b79355b970626e329"},
+    {file = "numpy-1.23.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:488a66cb667359534bc70028d653ba1cf307bae88eab5929cd707c761ff037db"},
+    {file = "numpy-1.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce03305dd694c4873b9429274fd41fc7eb4e0e4dea07e0af97a933b079a5814f"},
+    {file = "numpy-1.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8981d9b5619569899666170c7c9748920f4a5005bf79c72c07d08c8a035757b0"},
+    {file = "numpy-1.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a70a7d3ce4c0e9284e92285cba91a4a3f5214d87ee0e95928f3614a256a1488"},
+    {file = "numpy-1.23.4-cp311-cp311-win32.whl", hash = "sha256:5e13030f8793e9ee42f9c7d5777465a560eb78fa7e11b1c053427f2ccab90c79"},
+    {file = "numpy-1.23.4-cp311-cp311-win_amd64.whl", hash = "sha256:7607b598217745cc40f751da38ffd03512d33ec06f3523fb0b5f82e09f6f676d"},
+    {file = "numpy-1.23.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7ab46e4e7ec63c8a5e6dbf5c1b9e1c92ba23a7ebecc86c336cb7bf3bd2fb10e5"},
+    {file = "numpy-1.23.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8aae2fb3180940011b4862b2dd3756616841c53db9734b27bb93813cd79fce6"},
+    {file = "numpy-1.23.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c053d7557a8f022ec823196d242464b6955a7e7e5015b719e76003f63f82d0f"},
+    {file = "numpy-1.23.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0882323e0ca4245eb0a3d0a74f88ce581cc33aedcfa396e415e5bba7bf05f68"},
+    {file = "numpy-1.23.4-cp38-cp38-win32.whl", hash = "sha256:dada341ebb79619fe00a291185bba370c9803b1e1d7051610e01ed809ef3a4ba"},
+    {file = "numpy-1.23.4-cp38-cp38-win_amd64.whl", hash = "sha256:0fe563fc8ed9dc4474cbf70742673fc4391d70f4363f917599a7fa99f042d5a8"},
+    {file = "numpy-1.23.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894"},
+    {file = "numpy-1.23.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7"},
+    {file = "numpy-1.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735"},
+    {file = "numpy-1.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0"},
+    {file = "numpy-1.23.4-cp39-cp39-win32.whl", hash = "sha256:f2f390aa4da44454db40a1f0201401f9036e8d578a25f01a6e237cea238337ef"},
+    {file = "numpy-1.23.4-cp39-cp39-win_amd64.whl", hash = "sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e"},
+    {file = "numpy-1.23.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:61be02e3bf810b60ab74e81d6d0d36246dbfb644a462458bb53b595791251911"},
+    {file = "numpy-1.23.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:296d17aed51161dbad3c67ed6d164e51fcd18dbcd5dd4f9d0a9c6055dce30810"},
+    {file = "numpy-1.23.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4d52914c88b4930dafb6c48ba5115a96cbab40f45740239d9f4159c4ba779962"},
+    {file = "numpy-1.23.4.tar.gz", hash = "sha256:ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pandas = [
+    {file = "pandas-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0d8d7433d19bfa33f11c92ad9997f15a902bda4f5ad3a4814a21d2e910894484"},
+    {file = "pandas-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cc47f2ebaa20ef96ae72ee082f9e101b3dfbf74f0e62c7a12c0b075a683f03c"},
+    {file = "pandas-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e8e5edf97d8793f51d258c07c629bd49d271d536ce15d66ac00ceda5c150eb3"},
+    {file = "pandas-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41aec9f87455306496d4486df07c1b98c15569c714be2dd552a6124cd9fda88f"},
+    {file = "pandas-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c76f1d104844c5360c21d2ef0e1a8b2ccf8b8ebb40788475e255b9462e32b2be"},
+    {file = "pandas-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:1642fc6138b4e45d57a12c1b464a01a6d868c0148996af23f72dde8d12486bbc"},
+    {file = "pandas-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:171cef540bfcec52257077816a4dbbac152acdb8236ba11d3196ae02bf0959d8"},
+    {file = "pandas-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a68a9b9754efff364b0c5ee5b0f18e15ca640c01afe605d12ba8b239ca304d6b"},
+    {file = "pandas-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:86d87279ebc5bc20848b4ceb619073490037323f80f515e0ec891c80abad958a"},
+    {file = "pandas-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:207d63ac851e60ec57458814613ef4b3b6a5e9f0b33c57623ba2bf8126c311f8"},
+    {file = "pandas-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e252a9e49b233ff96e2815c67c29702ac3a062098d80a170c506dff3470fd060"},
+    {file = "pandas-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:de34636e2dc04e8ac2136a8d3c2051fd56ebe9fd6cd185581259330649e73ca9"},
+    {file = "pandas-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1d34b1f43d9e3f4aea056ba251f6e9b143055ebe101ed04c847b41bb0bb4a989"},
+    {file = "pandas-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b82ccc7b093e0a93f8dffd97a542646a3e026817140e2c01266aaef5fdde11b"},
+    {file = "pandas-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e30a31039574d96f3d683df34ccb50bb435426ad65793e42a613786901f6761"},
+    {file = "pandas-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62e61003411382e20d7c2aec1ee8d7c86c8b9cf46290993dd8a0a3be44daeb38"},
+    {file = "pandas-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc987f7717e53d372f586323fff441263204128a1ead053c1b98d7288f836ac9"},
+    {file = "pandas-1.5.0-cp38-cp38-win32.whl", hash = "sha256:e178ce2d7e3b934cf8d01dc2d48d04d67cb0abfaffdcc8aa6271fd5a436f39c8"},
+    {file = "pandas-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:33a9d9e21ab2d91e2ab6e83598419ea6a664efd4c639606b299aae8097c1c94f"},
+    {file = "pandas-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:73844e247a7b7dac2daa9df7339ecf1fcf1dfb8cbfd11e3ffe9819ae6c31c515"},
+    {file = "pandas-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e9c5049333c5bebf993033f4bf807d163e30e8fada06e1da7fa9db86e2392009"},
+    {file = "pandas-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85a516a7f6723ca1528f03f7851fa8d0360d1d6121cf15128b290cf79b8a7f6a"},
+    {file = "pandas-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:947ed9f896ee61adbe61829a7ae1ade493c5a28c66366ec1de85c0642009faac"},
+    {file = "pandas-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7f38d91f21937fe2bec9449570d7bf36ad7136227ef43b321194ec249e2149d"},
+    {file = "pandas-1.5.0-cp39-cp39-win32.whl", hash = "sha256:2504c032f221ef9e4a289f5e46a42b76f5e087ecb67d62e342ccbba95a32a488"},
+    {file = "pandas-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a4fc04838615bf0a8d3a03ed68197f358054f0df61f390bcc64fbe39e3d71ec"},
+    {file = "pandas-1.5.0.tar.gz", hash = "sha256:3ee61b881d2f64dd90c356eb4a4a4de75376586cd3c9341c6c0fcaae18d52977"},
+]
+pathspec = [
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+pep8-naming = [
+    {file = "pep8-naming-0.13.2.tar.gz", hash = "sha256:93eef62f525fd12a6f8c98f4dcc17fa70baae2f37fa1f73bec00e3e44392fa48"},
+    {file = "pep8_naming-0.13.2-py3-none-any.whl", hash = "sha256:59e29e55c478db69cffbe14ab24b5bd2cd615c0413edf790d47d3fb7ba9a4e23"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 pre-commit = []
-py = []
-pycodestyle = []
-pydantic = []
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+]
+pydantic = [
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
+]
 pyflakes = []
 pyparsing = []
-pytest = []
-pytest-cov = []
+pytest = [
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
 python-dateutil = []
-pytz = []
-pyyaml = []
+pytz = [
+    {file = "pytz-2022.4-py2.py3-none-any.whl", hash = "sha256:2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91"},
+    {file = "pytz-2022.4.tar.gz", hash = "sha256:48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
 requests = []
-scipy = []
-six = []
-toml = []
-tomli = []
-types-requests = []
-types-urllib3 = []
-typing-extensions = []
-urllib3 = []
-virtualenv = []
+scipy = [
+    {file = "scipy-1.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ee4ceed204f269da19f67f0115a85d3a2cd8547185037ad99a4025f9c61d02e9"},
+    {file = "scipy-1.9.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:17be1a7c68ec4c49d8cd4eb1655d55d14a54ab63012296bdd5921c92dc485acd"},
+    {file = "scipy-1.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72297eb9702576bd8f626bb488fd32bb35349d3120fc4a5e733db137f06c9a6"},
+    {file = "scipy-1.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa270cc6080c987929335c4cb94e8054fee9a6058cecff22276fa5dbab9856fc"},
+    {file = "scipy-1.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:22380e076a162e81b659d53d75b02e9c75ad14ea2d53d9c645a12543414e2150"},
+    {file = "scipy-1.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bbed414fc25d64bd6d1613dc0286fbf91902219b8be63ad254525162235b67e9"},
+    {file = "scipy-1.9.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:885b7ac56d7460544b2ef89ab9feafa30f4264c9825d975ef690608d07e6cc55"},
+    {file = "scipy-1.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5994a8232cc6510a8e85899661df2d11198bf362f0ffe6fbd5c0aca17ab46ce3"},
+    {file = "scipy-1.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e9c83dccac06f3b9aa02df69577f239758d5d0d0c069673fb0b47ecb971983d"},
+    {file = "scipy-1.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:92c5e627a0635ca02e6494bbbdb74f98d93ac8730416209d61de3b70c8a821be"},
+    {file = "scipy-1.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b6194da32e0ce9200b2eda4eb4edb89c5cb8b83d6deaf7c35f8ad3d5d7627d5c"},
+    {file = "scipy-1.9.2-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:148cb6f53d9d10dafde848e9aeb1226bf2809d16dc3221b2fa568130b6f2e586"},
+    {file = "scipy-1.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:658fd31c6ad4eb9fa3fd460fcac779f70a6bc7480288a211b7658a25891cf01d"},
+    {file = "scipy-1.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4012dbe540732311b8f4388b7e1482eb43a7cc0435bbf2b9916b3d6c38fb8d01"},
+    {file = "scipy-1.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:d6cb1f92ded3fc48f7dbe94d20d7b9887e13b874e79043907de541c841563b4c"},
+    {file = "scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1e3b23a82867018cd26255dc951789a7c567921622073e1113755866f1eae928"},
+    {file = "scipy-1.9.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:82e8bfb352aa9dce9a0ffe81f4c369a2c87c85533519441686f59f21d8c09697"},
+    {file = "scipy-1.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61b95283529712101bfb7c87faf94cb86ed9e64de079509edfe107e5cfa55733"},
+    {file = "scipy-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c8c29703202c39d699b0d6b164bde5501c212005f20abf46ae322b9307c8a41"},
+    {file = "scipy-1.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:7b2608b3141c257d01ae772e23b3de9e04d27344e6b68a890883795229cb7191"},
+    {file = "scipy-1.9.2.tar.gz", hash = "sha256:99e7720caefb8bca6ebf05c7d96078ed202881f61e0c68bd9e0f3e8097d6f794"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+types-requests = [
+    {file = "types-requests-2.28.11.2.tar.gz", hash = "sha256:fdcd7bd148139fb8eef72cf4a41ac7273872cad9e6ada14b11ff5dfdeee60ed3"},
+    {file = "types_requests-2.28.11.2-py3-none-any.whl", hash = "sha256:14941f8023a80b16441b3b46caffcbfce5265fd14555844d6029697824b5a2ef"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.25.tar.gz", hash = "sha256:5aef0e663724eef924afa8b320b62ffef2c1736c1fa6caecfc9bc6c8ae2c3def"},
+    {file = "types_urllib3-1.26.25-py3-none-any.whl", hash = "sha256:c1d78cef7bd581e162e46c20a57b2e1aa6ebecdcf01fd0713bb90978ff3e3427"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+]
+virtualenv = [
+    {file = "virtualenv-20.16.5-py3-none-any.whl", hash = "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"},
+    {file = "virtualenv-20.16.5.tar.gz", hash = "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Dan Meshkov <daniil.meshkov@opensea.io>", "Vicky Gong <vicky.gong@op
 description = "Open-Rarity library is an open standard that provides an easy, explanable and reproducible computation for NFT rarity"
 license = "Apache-2.0"
 name = "open-rarity"
-version = "0.6.1-beta"
+version = "0.7.0-beta"
 
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pep8-naming = "^0.13.1"
 pre-commit = "^2.19.0"
 pytest = "^7.1"
 pytest-cov = "^3.0"
+pytest-mock = "^3.10.0"
 types-requests = "^2.28.6"
 
 [tool.black]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -139,7 +139,7 @@ def onerare_rarity_tokens(
             '-1': 1111, '0': 1111, '1': 1111, '2': 1111, '3': 1111,
             '4': 1111, '5': 1111, '6': 1111, '7': 1111, '9': 1
         },
-        'meta trait: trait_count': {'3': 10000}
+        'meta_trait:trait_count': {'3': 10000}
     }
     """
     tokens = []
@@ -213,7 +213,7 @@ def generate_onerare_rarity_collection(
             '-1': 1111, '0': 1111, '1': 1111, '2': 1111, '3': 1111,
             '4': 1111, '5': 1111, '6': 1111, '7': 1111, '9': 1
         },
-        'meta trait: trait_count': {'3': 10000}
+        'meta_trait:trait_count': {'3': 10000}
     }
     """
     tokens = onerare_rarity_tokens(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,6 +31,22 @@ def create_evm_token(
     )
 
 
+def create_string_evm_token(
+    token_id: int,
+    contract_address: str = "0xaaa",
+    token_standard: TokenStandard = TokenStandard.ERC721,
+) -> Token:
+    string_metadata = TokenMetadata(
+        string_attributes={"test name": StringAttribute("test name", "test value")}
+    )
+    return create_evm_token(
+        token_id=token_id,
+        contract_address=contract_address,
+        token_standard=token_standard,
+        metadata=string_metadata,
+    )
+
+
 def create_numeric_evm_token(
     token_id: int,
     contract_address: str = "0xaaa",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,36 +63,34 @@ def create_numeric_evm_token(
     )
 
 
-def generate_uniform_attributes_count(
+def uniform_rarity_tokens(
     attribute_count: int = 5,
     values_per_attribute: int = 10,
     token_total_supply: int = 10000,
-) -> dict[str, dict[str, int]]:
-    """Generate trait counts with uniformly distributed attributes
-    Example output(with default inputs):
-    {
-        "0": {"0": 1,000, "1": 1,000, "2": 1,000, ... "9": 1,000},
-        ...
-        "4": {"0": 1,000, "1": 1,000, "2": 1,000, ... "9": 1,000},
-    }
-    This means every token in the 10,000 collection will have exactly
-    <attribute_count> traits.
+):
+    tokens = []
+    for token_id in range(token_total_supply):
+        string_attribute_dict = {}
 
-    """
+        # Construct attributes for the token such that the first bucket
+        # gets the first possible value for every attribute, second bucket
+        # gets the second possible value for every attribute, etc.
+        for attr_name in range(attribute_count):
+            string_attribute_dict[str(attr_name)] = StringAttribute(
+                name=str(attr_name),
+                value=str(token_id // (token_total_supply // values_per_attribute)),
+            )
 
-    if token_total_supply % values_per_attribute > 0:
-        raise Exception(
-            """token_total_supply must be divisible by values_per_attribute
-            for uniform count metadata"""
+        tokens.append(
+            Token(
+                token_identifier=EVMContractTokenIdentifier(
+                    contract_address="0x0", token_id=token_id
+                ),
+                token_standard=TokenStandard.ERC721,
+                metadata=TokenMetadata(string_attributes=string_attribute_dict),
+            )
         )
-
-    return {
-        str(attr_name): {
-            str(attr_value): token_total_supply // values_per_attribute
-            for attr_value in range(values_per_attribute)
-        }
-        for attr_name in range(attribute_count)
-    }
+    return tokens
 
 
 def generate_uniform_rarity_collection(
@@ -106,25 +104,59 @@ def generate_uniform_rarity_collection(
     Every bucket of (token_total_supply // values_per_attribute) gets the same
     attributes.
     """
-
-    collection_attributes_count = generate_uniform_attributes_count(
-        attribute_count, values_per_attribute, token_total_supply
+    tokens = uniform_rarity_tokens(
+        token_total_supply=token_total_supply,
+        attribute_count=attribute_count,
+        values_per_attribute=values_per_attribute,
     )
 
-    token_list = []
-    for token_id in range(token_total_supply):
+    return Collection(name="Uniform Rarity Collection", tokens=tokens)
+
+
+def onerare_rarity_tokens(
+    attribute_count: int = 3,
+    values_per_attribute: int = 10,
+    token_total_supply: int = 10000,
+) -> Collection:
+    """generate a Collection with a single token with one rare attribute;
+    otherwise uniformly distributed attributes.
+
+    For default params:
+        - every bundle of 1111 tokens have exactly the same attributes
+        - the first 9,999 tokens all have attributes with the same probabilities
+        - the last token has all unique attributes
+    Collection attributes frequency:
+    {
+        '0': {
+            '-1': 1111, '0': 1111, '1': 1111, '2': 1111, '3': 1111,
+            '4': 1111, '5': 1111, '6': 1111, '7': 1111, '9': 1
+        },
+        '1': {
+            '-1': 1111, '0': 1111, '1': 1111, '2': 1111, '3': 1111,
+            '4': 1111, '5': 1111, '6': 1111, '7': 1111, '9': 1
+        },
+        '2': {
+            '-1': 1111, '0': 1111, '1': 1111, '2': 1111, '3': 1111,
+            '4': 1111, '5': 1111, '6': 1111, '7': 1111, '9': 1
+        },
+        'meta trait: trait_count': {'3': 10000}
+    }
+    """
+    tokens = []
+
+    # Create attributes for all the uniform tokens
+    for token_id in range(token_total_supply - 1):
         string_attribute_dict = {}
 
-        # Construct attributes for the token such that the first bucket
-        # gets the first possible value for every attribute, second bucket
-        # gets the second possible value for every attribute, etc.
         for attr_name in range(attribute_count):
-            string_attribute_dict[str(attr_name)] = StringAttribute(
-                name=str(attr_name),
-                value=str(token_id // (token_total_supply // values_per_attribute)),
+            string_attribute_dict[AttributeName(attr_name)] = StringAttribute(
+                name=AttributeName(attr_name),
+                value=str(
+                    token_id // (token_total_supply // (values_per_attribute - 1)) - 1
+                ),
             )
 
-        token_list.append(
+        tokens.append(
             Token(
                 token_identifier=EVMContractTokenIdentifier(
                     contract_address="0x0", token_id=token_id
@@ -134,11 +166,25 @@ def generate_uniform_rarity_collection(
             )
         )
 
-    return Collection(
-        name="Uniform Rarity Collection",
-        tokens=token_list,
-        attributes_frequency_counts=collection_attributes_count,
+    # Create the attributes for the last rare token
+    rare_token_string_attribute_dict = {}
+    for attr_name in range(attribute_count):
+        rare_token_string_attribute_dict[AttributeName(attr_name)] = StringAttribute(
+            name=AttributeName(attr_name),
+            value=str(values_per_attribute),
+        )
+
+    tokens.append(
+        Token(
+            token_identifier=EVMContractTokenIdentifier(
+                contract_address="0x0", token_id=token_total_supply - 1
+            ),
+            token_standard=TokenStandard.ERC721,
+            metadata=TokenMetadata(string_attributes=rare_token_string_attribute_dict),
+        )
     )
+
+    return tokens
 
 
 def generate_onerare_rarity_collection(
@@ -170,49 +216,13 @@ def generate_onerare_rarity_collection(
         'meta trait: trait_count': {'3': 10000}
     }
     """
-    token_list = []
-
-    # Create attributes for all the uniform tokens
-    for token_id in range(token_total_supply - 1):
-        string_attribute_dict = {}
-
-        for attr_name in range(attribute_count):
-            string_attribute_dict[AttributeName(attr_name)] = StringAttribute(
-                name=AttributeName(attr_name),
-                value=str(
-                    token_id // (token_total_supply // (values_per_attribute - 1)) - 1
-                ),
-            )
-
-        token_list.append(
-            Token(
-                token_identifier=EVMContractTokenIdentifier(
-                    contract_address="0x0", token_id=token_id
-                ),
-                token_standard=TokenStandard.ERC721,
-                metadata=TokenMetadata(string_attributes=string_attribute_dict),
-            )
-        )
-
-    # Create the attributes for the last rare token
-    rare_token_string_attribute_dict = {}
-    for attr_name in range(attribute_count):
-        rare_token_string_attribute_dict[AttributeName(attr_name)] = StringAttribute(
-            name=AttributeName(attr_name),
-            value=str(values_per_attribute),
-        )
-
-    token_list.append(
-        Token(
-            token_identifier=EVMContractTokenIdentifier(
-                contract_address="0x0", token_id=token_total_supply - 1
-            ),
-            token_standard=TokenStandard.ERC721,
-            metadata=TokenMetadata(string_attributes=rare_token_string_attribute_dict),
-        )
+    tokens = onerare_rarity_tokens(
+        token_total_supply=token_total_supply,
+        attribute_count=attribute_count,
+        values_per_attribute=values_per_attribute,
     )
 
-    return Collection(name="One Rare Rarity Collection", tokens=token_list)
+    return Collection(name="One Rare Rarity Collection", tokens=tokens)
 
 
 def generate_collection_with_token_traits(
@@ -251,7 +261,7 @@ def generate_collection_with_token_traits(
 def get_mixed_trait_spread(
     max_total_supply: int = 10000,
 ) -> dict[str, dict[str, float]]:
-    # dict[attribute name, dict[attribute value, % of max supply]]
+    # dict[attribute name, dict[attribute value, items with that attribute]]
     return {
         "hat": {
             "cap": int(max_total_supply * 0.2),

--- a/tests/models/test_token.py
+++ b/tests/models/test_token.py
@@ -13,6 +13,20 @@ from tests.helpers import create_evm_token
 
 
 class TestToken:
+    metadata = TokenMetadata(
+        string_attributes={
+            "hat": StringAttribute(name="hat", value="blue"),
+            "shirt": StringAttribute(name="shirt", value="red"),
+        },
+        numeric_attributes={
+            "level": NumericAttribute(name="level", value=1),
+        },
+    )
+    token = create_evm_token(token_id=1, metadata=metadata)
+
+    def test_token_metadata(self):
+        assert self.token.metadata == self.metadata
+
     def test_create_metaplex_non_fungible(self):
         token = Token(
             token_identifier=SolanaMintAddressTokenIdentifier(
@@ -162,3 +176,43 @@ class TestToken:
             t.metadata != expected_equal_metadata_tokens[0].metadata
             for t in expected_not_equal
         )
+
+    def test_has_attribute(self):
+        assert self.token.has_attribute("hat")
+        assert self.token.has_attribute("shirt")
+        assert self.token.has_attribute("level")
+        assert not self.token.has_attribute("not an attribute")
+
+    def test_trait_count(self):
+        assert self.token.trait_count() == 3
+        non_null_traits = {"hat": "cap", "shirt": "blue", "level": 1, "size": "large"}
+
+        token_with_none = create_evm_token(
+            token_id=1,
+            metadata=TokenMetadata.from_attributes(
+                {**non_null_traits, "something": "none"}
+            ),
+        )
+        assert token_with_none.trait_count() == 4
+
+        token_with_none = create_evm_token(
+            token_id=1,
+            metadata=TokenMetadata.from_attributes(
+                {**non_null_traits, "something": ""}
+            ),
+        )
+        assert token_with_none.trait_count() == 4
+
+        token_with_0 = create_evm_token(
+            token_id=1,
+            metadata=TokenMetadata.from_attributes({**non_null_traits, "something": 0}),
+        )
+        assert token_with_0.trait_count() == 5
+
+        token_with_valid_null = create_evm_token(
+            token_id=1,
+            metadata=TokenMetadata.from_attributes(
+                {**non_null_traits, "something": "null"}
+            ),
+        )
+        assert token_with_valid_null.trait_count() == 5

--- a/tests/models/test_token_metadata.py
+++ b/tests/models/test_token_metadata.py
@@ -11,6 +11,20 @@ from open_rarity.models.token_metadata import (
 
 
 class TestTokenMetadata:
+    token_metadata = TokenMetadata(
+        string_attributes={
+            "hat": StringAttribute(name="hat", value="blue cap"),
+        },
+        numeric_attributes={
+            "integer trait": NumericAttribute(name="integer trait", value=1),
+        },
+        date_attributes={
+            "created": DateAttribute(
+                name="created", value=int(datetime.now().timestamp())
+            ),
+        },
+    )
+
     def test_from_attributes_valid_types(self):
         created = datetime.now()
         token_metadata = TokenMetadata.from_attributes(
@@ -47,3 +61,70 @@ class TestTokenMetadata:
             )
 
         assert "Provided attribute value has invalid type" in str(excinfo.value)
+
+    def test_attribute_exists(self):
+        assert self.token_metadata.attribute_exists("hat")
+        assert self.token_metadata.attribute_exists("HAT")
+        assert self.token_metadata.attribute_exists("integer trait")
+        assert self.token_metadata.attribute_exists("integer trait     ")
+        assert self.token_metadata.attribute_exists("created")
+        assert not self.token_metadata.attribute_exists("scarf")
+        assert not TokenMetadata().attribute_exists("hat")
+
+    def test_add_attribute_empty(self):
+        token_metadata = TokenMetadata()
+        token_metadata.add_attribute(StringAttribute(name="hat", value="blue cap"))
+        token_metadata.add_attribute(NumericAttribute(name="integer trait", value=1))
+        token_metadata.add_attribute(
+            DateAttribute(name="created", value=int(datetime.now().timestamp()))
+        )
+
+        assert token_metadata.string_attributes == {
+            "hat": StringAttribute(name="hat", value="blue cap"),
+        }
+        assert token_metadata.numeric_attributes == {
+            "integer trait": NumericAttribute(name="integer trait", value=1),
+        }
+        assert token_metadata.date_attributes == {
+            "created": DateAttribute(
+                name="created", value=int(datetime.now().timestamp())
+            ),
+        }
+
+    def test_add_attribute_non_empty(self):
+        created_date = datetime.now()
+        token_metadata = TokenMetadata.from_attributes(
+            {
+                "hat": "blue cap",
+                "created": created_date,
+                "integer trait": 1,
+                "float trait": 203.5,
+                "PANTS ": "jeans",
+            }
+        )
+        token_metadata.add_attribute(StringAttribute(name="scarf", value="old"))
+        token_metadata.add_attribute(StringAttribute(name="scarf", value="wrap-around"))
+        token_metadata.add_attribute(NumericAttribute(name="integer trait 2", value=10))
+        created_date_2 = datetime.now()
+        token_metadata.add_attribute(
+            DateAttribute(name="created 2", value=int(created_date_2.timestamp()))
+        )
+
+        assert token_metadata.string_attributes == {
+            "hat": StringAttribute(name="hat", value="blue cap"),
+            "pants": StringAttribute(name="pants", value="jeans"),
+            "scarf": StringAttribute(name="scarf", value="wrap-around"),
+        }
+        assert token_metadata.numeric_attributes == {
+            "integer trait": NumericAttribute(name="integer trait", value=1),
+            "float trait": NumericAttribute(name="float trait", value=203.5),
+            "integer trait 2": NumericAttribute(name="integer trait 2", value=10),
+        }
+        assert token_metadata.date_attributes == {
+            "created": DateAttribute(
+                name="created", value=int(created_date.timestamp())
+            ),
+            "created 2": DateAttribute(
+                name="created 2", value=int(created_date_2.timestamp())
+            ),
+        }

--- a/tests/resolver/test_external_rarity_provider.py
+++ b/tests/resolver/test_external_rarity_provider.py
@@ -4,12 +4,16 @@ from open_rarity.models.collection import Collection
 from open_rarity.models.token import Token
 from open_rarity.resolver.models.collection_with_metadata import CollectionWithMetadata
 from open_rarity.resolver.models.token_with_rarity_data import (
+    EXTERNAL_RANK_PROVIDERS,
     RankProvider,
     TokenWithRarityData,
 )
 from open_rarity.resolver.rarity_providers.external_rarity_provider import (
     ExternalRarityProvider,
 )
+from open_rarity.resolver.rarity_providers.rarity_sniffer import RaritySnifferResolver
+from open_rarity.resolver.rarity_providers.rarity_sniper import RaritySniperResolver
+from open_rarity.resolver.rarity_providers.trait_sniper import TraitSniperResolver
 
 
 class TestExternalRarityProvider:
@@ -34,11 +38,11 @@ class TestExternalRarityProvider:
 
     @pytest.mark.skipif(
         "not config.getoption('--run-resolvers')",
-        reason="This tests runs too long due to rate limits to have as part of CI/CD "
-        "but should be run whenver someone changes resolvers. Also needs "
+        reason="Dependent on external API and takes too long due to rate limits"
+        "Should only be used to verify external API changes and needs "
         "TRAIT_SNIPER_API_KEY key",
     )
-    def test_fetch_and_update_ranks_all_providers(self):
+    def test_fetch_and_update_ranks_real_api_calls(self):
         provider = ExternalRarityProvider()
         tokens_with_rarity = [TokenWithRarityData(token=self.bayc_token_1, rarities=[])]
         provider.fetch_and_update_ranks(
@@ -49,20 +53,39 @@ class TestExternalRarityProvider:
         rarities = tokens_with_rarity[0].rarities
         assert len(rarities) == 3
 
-    def test_fetch_and_update_ranks_rarity_sniffer_sniper(self):
+    def test_fetch_and_update_ranks_mocked_api(self, mocker):
         provider = ExternalRarityProvider()
         tokens_with_rarity = [TokenWithRarityData(token=self.bayc_token_1, rarities=[])]
+
+        rarity_sniffer_rank = 3256
+        rarity_sniper_rank = 3250
+        trait_sniper_rank = 3000
+        mocker.patch.object(
+            RaritySnifferResolver,
+            "get_all_ranks",
+            return_value={"1": rarity_sniffer_rank},
+        )
+        mocker.patch.object(
+            TraitSniperResolver, "get_all_ranks", return_value={"1": trait_sniper_rank}
+        )
+        mocker.patch.object(
+            RaritySniperResolver, "get_rank", return_value=rarity_sniper_rank
+        )
+
         provider.fetch_and_update_ranks(
             collection_with_metadata=self.bayc_collection,
             tokens_with_rarity=tokens_with_rarity,
             cache_external_ranks=False,
-            rank_providers=[RankProvider.RARITY_SNIFFER, RankProvider.RARITY_SNIPER],
         )
         rarities = tokens_with_rarity[0].rarities
-        assert len(rarities) == 2
+        assert len(rarities) == 3
         for rarity in rarities:
-            assert rarity.provider in [
-                RankProvider.RARITY_SNIFFER,
-                RankProvider.RARITY_SNIPER,
-            ]
-            assert rarity.rank
+            assert rarity.provider in EXTERNAL_RANK_PROVIDERS
+            if rarity.provider == RankProvider.RARITY_SNIFFER:
+                assert rarity.rank == rarity_sniffer_rank
+            elif rarity.provider == RankProvider.RARITY_SNIPER:
+                assert rarity.rank == rarity_sniper_rank
+            elif rarity.provider == RankProvider.TRAITS_SNIPER:
+                assert rarity.rank == trait_sniper_rank
+            else:
+                raise Exception("Unexpected provider")

--- a/tests/resolver/test_testset_resolver.py
+++ b/tests/resolver/test_testset_resolver.py
@@ -23,7 +23,7 @@ class TestTestsetResolver:
         # Middle token, official rank=3503
         509: {
             # https://app.traitsniper.com/boredapeyachtclub?view=509
-            RankProvider.TRAITS_SNIPER: "3370",
+            RankProvider.TRAITS_SNIPER: "2730",
             # https://raritysniffer.com/viewcollection/boredapeyachtclub?nft=509
             RankProvider.RARITY_SNIFFER: "3257",
             # https://raritysniper.com/bored-ape-yacht-club/509
@@ -34,7 +34,7 @@ class TestTestsetResolver:
         # Common token, official rank=7623
         8002: {
             # https://app.traitsniper.com/boredapeyachtclub?view=8002
-            RankProvider.TRAITS_SNIPER: "6810",
+            RankProvider.TRAITS_SNIPER: "6271",
             # https://raritysniffer.com/viewcollection/boredapeyachtclub?nft=8002
             RankProvider.RARITY_SNIFFER: "7709",
             # https://raritysniper.com/bored-ape-yacht-club/8002
@@ -75,7 +75,6 @@ class TestTestsetResolver:
                 RankProvider.RARITY_SNIPER,
             ],
             filename="resolver/sample_files/bayc.json",
-            # max_tokens_to_calculate=100,
         )
         # Read the file and verify columns values are as expected for the given tokens
         output_filename = "testset_boredapeyachtclub.csv"
@@ -105,8 +104,10 @@ class TestTestsetResolver:
     @pytest.mark.skipif(
         "not config.getoption('--run-resolvers')",
         reason="This tests runs too long to have as part of CI/CD but should be "
-        "run whenver someone changes resolver and requires TRAIT_SNIPER_API_KEY",
+        "run whenever someone changes resolver and requires TRAIT_SNIPER_API_KEY",
     )
+    # Warning: Trait Sniper ranks are not stable, so this test may fail.
+    # If it does, just update the expected values to be what's on the site.
     def test_resolve_collection_data_traits_sniper(self):
         # Have the resolver pull in BAYC rarity rankings from various sources
         # Just do a check to ensure the ranks from different providers are

--- a/tests/test_rarity_ranker.py
+++ b/tests/test_rarity_ranker.py
@@ -8,7 +8,30 @@ from open_rarity.models.token_metadata import TokenMetadata
 from open_rarity.models.token_ranking_features import TokenRankingFeatures
 from open_rarity.models.token_rarity import TokenRarity
 from open_rarity.rarity_ranker import RarityRanker
+from open_rarity.scoring.scorer import Scorer
 from tests.helpers import generate_collection_with_token_traits
+
+
+def verify_token_rarities(token_rarities: list[TokenRarity], expected_data: list[dict]):
+    """
+    Parameters
+    ----------
+    expected_data: list[dict]
+        must be a list of dicts with the following keys:
+        - id (token id)
+        - unique_traits
+        - rank
+        - score (optional)
+    """
+    for token_rarity, expected in zip(token_rarities, expected_data):
+        assert token_rarity.rank == expected["rank"]
+        assert token_rarity.token.token_identifier.token_id == expected["id"]
+        assert (
+            token_rarity.token_features.unique_attribute_count
+            == expected["unique_traits"]
+        )
+        if "score" in expected:
+            assert token_rarity.score == expected["score"]
 
 
 class TestRarityRanker:
@@ -46,57 +69,107 @@ class TestRarityRanker:
         assert tokens[0].score == 0
         assert tokens[0].rank == 1
 
-    def test_rarity_ranker_unique_scores(self) -> None:
-
-        test_collection: Collection = generate_collection_with_token_traits(
+    def test_rarity_ranker_equal_score_and_unique_trait(self) -> None:
+        test_collection = generate_collection_with_token_traits(
             [
+                # Token 0
                 {
-                    "trait1": "value1",
-                    "trait2": "value1",
-                    "trait3": "value2",
-                },  # Token 0
+                    "trait1": "value1",  # 100%
+                    "trait2": "value1",  # unique trait
+                    "trait3": "value2",  # 75%
+                },
+                # Token 1
                 {
-                    "trait1": "value1",
-                    "trait2": "value2",
-                    "trait3": "value2",
-                },  # Token 1
+                    "trait1": "value1",  # 75%
+                    "trait2": "value2",  # 75%
+                    "trait3": "value2",  # 50%
+                },
+                # Token 2
                 {
-                    "trait1": "value1",
-                    "trait2": "value2",
-                    "trait3": " value3",
-                },  # Token 2
+                    "trait1": "value1",  # 100%
+                    "trait2": "value2",  # 75%
+                    "trait3": "value3",  # unique trait
+                },
+                # Token 3
                 {
-                    "trait1": "value1",
-                    "trait2": "value4",
-                    "trait3": " value2",
-                    "trait4": " value1",
+                    "trait1": "value1",  # 100%
+                    "trait2": "value2",  # 75%
+                    "trait3": "value2",  # 75%
+                    "trait4": "value1",  # unique trait
+                },
+            ]
+        )
+
+        token_rarities = RarityRanker.rank_collection(collection=test_collection)
+        expected_tokens_in_rank_order = [
+            {"id": 3, "unique_traits": 2, "rank": 1},
+            {"id": 0, "unique_traits": 1, "rank": 2},
+            {"id": 2, "unique_traits": 1, "rank": 2},
+            {"id": 1, "unique_traits": 0, "rank": 4},
+        ]
+        verify_token_rarities(token_rarities, expected_tokens_in_rank_order)
+
+    def test_rarity_ranker_unique_scores(self) -> None:
+        test_collection = generate_collection_with_token_traits(
+            [
+                # Token 0
+                {
+                    "trait1": "value1",  # 100%
+                    "trait2": "value1",  # unique trait
+                    "trait3": "value2",  # 75%
+                },
+                # Token 1
+                {
+                    "trait1": "value1",  # 75%
+                    "trait2": "value2",  # 50%
+                    "trait3": "value2",  # 50%
+                },
+                # Token 2
+                {
+                    "trait1": "value1",  # 100%
+                    "trait2": "value2",  # 50%
+                    "trait3": "value3",  # unique trait
+                },
+                # Token 3
+                {
+                    "trait1": "value1",  # 100%
+                    "trait2": "value4",  # unique trait
+                    "trait3": "value2",  # 50%
+                    "trait4": "value1",  # unique trait
                 },  # Token 3
             ]
         )
 
-        tokens: list[TokenRarity] = RarityRanker.rank_collection(
-            collection=test_collection
-        )
-
-        assert tokens[0].token.token_identifier.token_id == 3
-        assert tokens[0].score == 1.4139176838874645
-        assert tokens[0].rank == 1
-        assert tokens[0].token_features.unique_attribute_count == 2
-
-        assert tokens[1].token.token_identifier.token_id == 2
-        assert tokens[1].score == 1.0936672479356941
-        assert tokens[1].rank == 2
-        assert tokens[1].token_features.unique_attribute_count == 1
-
-        assert tokens[2].token.token_identifier.token_id == 0
-        assert tokens[2].score == 0.906332752064306
-        assert tokens[2].rank == 3
-        assert tokens[2].token_features.unique_attribute_count == 1
-
-        assert tokens[3].token.token_identifier.token_id == 1
-        assert tokens[3].score == 0.5860823161125354
-        assert tokens[3].rank == 4
-        assert tokens[3].token_features.unique_attribute_count == 0
+        token_rarities = RarityRanker.rank_collection(test_collection)
+        scorer = Scorer()
+        expected_scores = scorer.score_collection(test_collection)
+        expected_tokens_in_rank_order = [
+            {
+                "id": 3,
+                "unique_traits": 3,
+                "rank": 1,
+                "score": expected_scores[3],
+            },
+            {
+                "id": 2,
+                "unique_traits": 1,
+                "rank": 2,
+                "score": expected_scores[2],
+            },
+            {
+                "id": 0,
+                "unique_traits": 1,
+                "rank": 3,
+                "score": expected_scores[0],
+            },
+            {
+                "id": 1,
+                "unique_traits": 0,
+                "rank": 4,
+                "score": expected_scores[1],
+            },
+        ]
+        verify_token_rarities(token_rarities, expected_tokens_in_rank_order)
 
     def test_rarity_ranker_same_scores(self) -> None:
         test_collection: Collection = generate_collection_with_token_traits(
@@ -129,34 +202,16 @@ class TestRarityRanker:
             ]
         )
 
-        tokens: list[TokenRarity] = RarityRanker.rank_collection(
-            collection=test_collection
-        )
+        token_rarities = RarityRanker.rank_collection(test_collection)
 
-        assert tokens[0].token.token_identifier.token_id == 4
-        assert tokens[0].score == 1.3926137488801251
-        assert tokens[0].rank == 1
-        assert tokens[0].token_features.unique_attribute_count == 2
-
-        assert tokens[1].token.token_identifier.token_id == 3
-        assert tokens[1].score == 1.1338031424711967
-        assert tokens[1].rank == 2
-        assert tokens[1].token_features.unique_attribute_count == 1
-
-        assert tokens[2].token.token_identifier.token_id == 0
-        assert tokens[2].score == 0.8749925360622679
-        assert tokens[2].rank == 3
-        assert tokens[2].token_features.unique_attribute_count == 0
-
-        assert tokens[3].token.token_identifier.token_id == 1
-        assert tokens[3].score == 0.8749925360622679
-        assert tokens[3].rank == 3
-        assert tokens[3].token_features.unique_attribute_count == 0
-
-        assert tokens[4].token.token_identifier.token_id == 2
-        assert tokens[4].score == 0.7235980365241422
-        assert tokens[4].rank == 5
-        assert tokens[4].token_features.unique_attribute_count == 0
+        expected_tokens_in_rank_order = [
+            {"id": 4, "unique_traits": 2, "rank": 1, "score": 1.3926137488801251},
+            {"id": 3, "unique_traits": 1, "rank": 2, "score": 1.1338031424711967},
+            {"id": 0, "unique_traits": 0, "rank": 3, "score": 0.8749925360622679},
+            {"id": 1, "unique_traits": 0, "rank": 3, "score": 0.8749925360622679},
+            {"id": 2, "unique_traits": 0, "rank": 5, "score": 0.7235980365241422},
+        ]
+        verify_token_rarities(token_rarities, expected_tokens_in_rank_order)
 
     def test_set_ranks_same_unique_different_ic_score(self):
         token_rarities: list[TokenRarity] = []


### PR DESCRIPTION
# Adding Trait Count to OpenRarity
We are automatically adding TraitCount as a meta trait upon Collection initialization so that the OpenRarity ranking and scoring algorithm takes into consideration trait count as an attribute to impact ranking **for all collections**. We will not modify open rarity scoring or ranking algorithm directly in any form. 

For more detailed information and analysis, please review this blog post -https://mirror.xyz/openrarity.eth/oNo7AmgXopMCKq95gv_Xe0p5pKQ_qHWKzTV11DpFxgE

# Definition of Trait Count
TraitCount is defined to be the sum of unique traits an asset has with a non-empty value
- We consider empty to be where the normalized attribute value is any of `(“”, “none”, None)`

# Methodology
Upon `Collection` initialization, we will modify the `tokens` input by adding in a new `StringAttribute` to the tokens' metadata with:
- `attribute.name` = `“meta trait: trait_count”`
    - Naming to decrease collision with existing trait
- `attribute.value` = token.trait_count()
- Note 1: We will not remove any existing fields, regardless if naming is similiar to “trait count”, “trait_count” etc. The reason is because probability and rankings will not be impacted as probabilities will be the same.
- Note 2: There’s a small chance we override attributes with “meta trait: trait_count” but don’t believe it’s likely enough to matter.